### PR TITLE
VR Opacity

### DIFF
--- a/src/app/app-common/OpenVRKneeboard.cpp
+++ b/src/app/app-common/OpenVRKneeboard.cpp
@@ -190,7 +190,9 @@ void OpenVRKneeboard::Tick() {
   const auto displayTime = this->GetDisplayTime();
   const auto hmdPose = this->GetHMDPose(displayTime);
   const auto kneeboardPose = this->GetKneeboardPose(vr, hmdPose);
-  const auto size = this->GetKneeboardSize(config, hmdPose, kneeboardPose);
+  const auto isLookingAtKneeboard
+    = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
+  const auto size = this->GetKneeboardSize(config, isLookingAtKneeboard);
 
   CHECK(SetOverlayWidthInMeters, mOverlay, size.x);
 

--- a/src/app/app-common/OpenVRKneeboard.cpp
+++ b/src/app/app-common/OpenVRKneeboard.cpp
@@ -185,22 +185,17 @@ void OpenVRKneeboard::Tick() {
   }
 
   const auto config = snapshot.GetConfig();
-  const auto& vr = config.vr;
-
   const auto displayTime = this->GetDisplayTime();
-  const auto hmdPose = this->GetHMDPose(displayTime);
-  const auto kneeboardPose = this->GetKneeboardPose(vr, hmdPose);
-  const auto isLookingAtKneeboard
-    = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
-  const auto size = this->GetKneeboardSize(config, isLookingAtKneeboard);
+  const auto renderParams
+    = this->GetRenderParameters(config, this->GetHMDPose(displayTime));
 
-  CHECK(SetOverlayWidthInMeters, mOverlay, size.x);
+  CHECK(SetOverlayWidthInMeters, mOverlay, renderParams.mKneeboardSize.x);
 
   // Transpose to fit OpenVR's in-memory layout
   // clang-format off
   const auto transform = (
-    Matrix::CreateFromQuaternion(kneeboardPose.mOrientation)
-    * Matrix::CreateTranslation(kneeboardPose.mPosition)
+    Matrix::CreateFromQuaternion(renderParams.mKneeboardPose.mOrientation)
+    * Matrix::CreateTranslation(renderParams.mKneeboardPose.mPosition)
   ).Transpose();
   // clang-format on
 

--- a/src/app/app-common/VRConfig.cpp
+++ b/src/app/app-common/VRConfig.cpp
@@ -62,6 +62,12 @@ void from_json(const nlohmann::json& j, VRConfig& vrc) {
   if (j.contains("openXRMode")) {
     vrc.mOpenXRMode = j.at("openXRMode").get<OpenXRMode>();
   }
+
+  if (j.contains("opacity")) {
+    auto opacity = j.at("opacity");
+    vrc.mNormalOpacity = opacity.at("normal");
+    vrc.mGazeOpacity = opacity.at("gaze");
+  }
 }
 
 void to_json(nlohmann::json& j, const VRConfig& vrc) {
@@ -89,6 +95,13 @@ void to_json(nlohmann::json& j, const VRConfig& vrc) {
      static_cast<bool>(vrc.mFlags & VRRenderConfig::Flags::GAZE_ZOOM)},
     {"enableSteamVR", vrc.mEnableSteamVR},
     {"openXRMode", vrc.mOpenXRMode},
+    {
+      "opacity",
+      {
+        {"normal", vrc.mNormalOpacity},
+        {"gaze", vrc.mGazeOpacity},
+      },
+    },
   };
 }
 }// namespace OpenKneeboard

--- a/src/app/app-common/include/OpenKneeboard/OpenVRKneeboard.h
+++ b/src/app/app-common/include/OpenKneeboard/OpenVRKneeboard.h
@@ -59,7 +59,8 @@ class OpenVRKneeboard final : private VRKneeboard {
   SHM::Reader mSHM;
 
   winrt::com_ptr<ID3D11Texture2D> mOpenVRTexture;
-  uint64_t mSequenceNumber = ~(0ui64);
+  winrt::com_ptr<ID3D11RenderTargetView> mRenderTargetView;
+  uint64_t mCacheKey = ~(0ui64);
 };
 
 }// namespace OpenKneeboard

--- a/src/app/app-winui3/CMakeLists.txt
+++ b/src/app/app-winui3/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
   TARGET_FILE_LIBRARIES
   OpenKneeboard::App::Common
   OpenKneeboard-D2DErrorRenderer
+  OpenKneeboard-D3D11
   OpenKneeboard-DXResources
   OpenKneeboard-GameEvent
   OpenKneeboard-GetSystemColor

--- a/src/app/app-winui3/VRSettingsPage.idl
+++ b/src/app/app-winui3/VRSettingsPage.idl
@@ -24,5 +24,8 @@ namespace OpenKneeboardApp
         Boolean DiscardOculusDepthInformation;
 
         UInt8 OpenXRMode;
+
+        UInt8 NormalOpacity;
+        UInt8 GazeOpacity;
     }
 }

--- a/src/app/app-winui3/VRSettingsPage.xaml
+++ b/src/app/app-winui3/VRSettingsPage.xaml
@@ -11,6 +11,7 @@
     <local:MetersNumberFormatter x:Key="MetersFormatter" />
     <local:DegreesValueConverter x:Key="DegreesConverter" />
     <local:MultiplierValueConverter x:Key="MultiplierConverter" />
+    <local:PercentValueConverter x:Key="PercentConverter" />
   </Page.Resources>
   <ScrollViewer>
     <StackPanel Margin="16" Spacing="8" x:DefaultBindMode="TwoWay">
@@ -36,18 +37,18 @@
         BorderThickness="1"
         Padding="8">
         <StackPanel Spacing="12">
-					<ToggleSwitch
-						Header="Gaze-based zoom"
-						OnContent="On"
-						OffContent="Off"
-						IsOn="{x:Bind GazeZoomEnabled}"
-					/>
-					<ToggleSwitch
-						Header="Discard Oculus SDK depth information - required for DCS World"
-						OnContent="On"
-						OffContent="Off"
-						IsOn="{x:Bind DiscardOculusDepthInformation}"
-					/>
+          <ToggleSwitch
+            Header="Gaze-based zoom"
+            OnContent="On"
+            OffContent="Off"
+            IsOn="{x:Bind GazeZoomEnabled}"
+          />
+          <ToggleSwitch
+            Header="Discard Oculus SDK depth information - required for DCS World"
+            OnContent="On"
+            OffContent="Off"
+            IsOn="{x:Bind DiscardOculusDepthInformation}"
+          />
           <ToggleSwitch
             Header="SteamVR support"
             OnContent="Enabled"
@@ -224,6 +225,33 @@
               ThumbToolTipValueConverter="{StaticResource DegreesConverter}"
             />
           </Grid>
+        </StackPanel>
+      </Grid>
+      <Grid
+        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+        CornerRadius="4"
+        BorderThickness="1"
+        Padding="8">
+        <StackPanel Spacing="12">
+          <Slider
+            Header="Opacity when not looking at the kneeboard"
+            Value="{x:Bind NormalOpacity}"
+            Minimum="0"
+            Maximum="100"
+            TickFrequency="10"
+            TickPlacement="Outside"
+            ThumbToolTipValueConverter="{StaticResource PercentConverter}"
+          />
+          <Slider
+            Header="Opacity when looking at the kneeboard"
+            Value="{x:Bind GazeOpacity}"
+            Minimum="0"
+            Maximum="100"
+            TickFrequency="10"
+            TickPlacement="Outside"
+            ThumbToolTipValueConverter="{StaticResource PercentConverter}"
+          />
         </StackPanel>
       </Grid>
     </StackPanel>

--- a/src/app/app-winui3/VRSettingsPage.xaml.cpp
+++ b/src/app/app-winui3/VRSettingsPage.xaml.cpp
@@ -81,6 +81,8 @@ fire_and_forget VRSettingsPage::RestoreDefaults(
          L"SteamVREnabled",
          L"GazeZoomEnabled",
          L"DiscardOculusDepthInformation",
+         L"NormalOpacity",
+         L"GazeOpacity",
        }) {
     mPropertyChangedEvent(*this, PropertyChangedEventArgs(prop));
   }
@@ -270,6 +272,26 @@ void VRSettingsPage::DiscardOculusDepthInformation(bool discard) {
   } else {
     config.mFlags &= ~VRRenderConfig::Flags::DISCARD_DEPTH_INFORMATION;
   }
+  gKneeboard->SetVRConfig(config);
+}
+
+uint8_t VRSettingsPage::NormalOpacity() {
+  return std::lround(gKneeboard->GetVRConfig().mNormalOpacity * 100);
+}
+
+void VRSettingsPage::NormalOpacity(uint8_t value) {
+  auto config = gKneeboard->GetVRConfig();
+  config.mNormalOpacity = value / 100.0f;
+  gKneeboard->SetVRConfig(config);
+}
+
+uint8_t VRSettingsPage::GazeOpacity() {
+  return std::lround(gKneeboard->GetVRConfig().mGazeOpacity * 100);
+}
+
+void VRSettingsPage::GazeOpacity(uint8_t value) {
+  auto config = gKneeboard->GetVRConfig();
+  config.mGazeOpacity = value / 100.0f;
   gKneeboard->SetVRConfig(config);
 }
 

--- a/src/app/app-winui3/VRSettingsPage.xaml.h
+++ b/src/app/app-winui3/VRSettingsPage.xaml.h
@@ -67,6 +67,11 @@ struct VRSettingsPage : VRSettingsPageT<VRSettingsPage> {
   bool DiscardOculusDepthInformation();
   void DiscardOculusDepthInformation(bool value);
 
+  uint8_t NormalOpacity();
+  void NormalOpacity(uint8_t);
+  uint8_t GazeOpacity();
+  void GazeOpacity(uint8_t);
+
   winrt::event_token PropertyChanged(
     winrt::Microsoft::UI::Xaml::Data::PropertyChangedEventHandler const&
       handler);

--- a/src/injectables/CMakeLists.txt
+++ b/src/injectables/CMakeLists.txt
@@ -105,13 +105,14 @@ target_link_libraries(
   PRIVATE
   ThirdParty::OpenXR
   ThirdParty::DirectXTK
-  OpenKneeboard-config
-  OpenKneeboard-dprint
+  OpenKneeboard-D3D11
   OpenKneeboard-RayIntersectsRect
-  OpenKneeboard-scope_guard
-  OpenKneeboard-shims
   OpenKneeboard-SHM
   OpenKneeboard-VRKneeboard
+  OpenKneeboard-config
+  OpenKneeboard-dprint
+  OpenKneeboard-scope_guard
+  OpenKneeboard-shims
   NuGet::CppWinRT::Base
 )
 

--- a/src/injectables/CMakeLists.txt
+++ b/src/injectables/CMakeLists.txt
@@ -80,6 +80,7 @@ target_link_libraries(
   detours-ext
   OpenKneeboard-config
   OpenKneeboard-dprint
+  OpenKneeboard-D3D11
   oculus-hooks
   oculus-sdk-headers)
 

--- a/src/injectables/OculusD3D11Kneeboard.h
+++ b/src/injectables/OculusD3D11Kneeboard.h
@@ -42,7 +42,8 @@ class OculusD3D11Kneeboard final : public OculusKneeboard::Renderer {
   virtual bool Render(
     ovrSession session,
     ovrTextureSwapChain swapChain,
-    const SHM::Snapshot& snapshot) override final;
+    const SHM::Snapshot& snapshot,
+    const VRKneeboard::RenderParameters&) override final;
 
  private:
   std::vector<winrt::com_ptr<ID3D11RenderTargetView>> mRenderTargets;

--- a/src/injectables/OculusD3D12Kneeboard.cpp
+++ b/src/injectables/OculusD3D12Kneeboard.cpp
@@ -123,7 +123,8 @@ ovrTextureSwapChain OculusD3D12Kneeboard::CreateSwapChain(ovrSession session) {
 bool OculusD3D12Kneeboard::Render(
   ovrSession session,
   ovrTextureSwapChain swapChain,
-  const SHM::Snapshot& snapshot) {
+  const SHM::Snapshot& snapshot,
+  const VRKneeboard::RenderParameters&) {
   auto ovr = OVRProxy::Get();
   const auto config = snapshot.GetConfig();
 

--- a/src/injectables/OculusD3D12Kneeboard.h
+++ b/src/injectables/OculusD3D12Kneeboard.h
@@ -42,7 +42,8 @@ class OculusD3D12Kneeboard final : public OculusKneeboard::Renderer {
   virtual bool Render(
     ovrSession session,
     ovrTextureSwapChain swapChain,
-    const SHM::Snapshot& snapshot) override;
+    const SHM::Snapshot& snapshot,
+    const VRKneeboard::RenderParameters&) override final;
 
  private:
   ID3D12CommandQueueExecuteCommandListsHook mExecuteCommandListsHook;

--- a/src/injectables/OculusKneeboard.cpp
+++ b/src/injectables/OculusKneeboard.cpp
@@ -86,7 +86,6 @@ ovrResult OculusKneeboard::OnOVREndFrame(
 
   static bool sFirst = true;
   if (sFirst) {
-    OPENKNEEBOARD_BREAK;
     dprint(__FUNCTION__);
     sFirst = false;
   }
@@ -114,16 +113,16 @@ ovrResult OculusKneeboard::OnOVREndFrame(
     }
   }
 
-  if (!mRenderer->Render(session, mSwapChain, snapshot)) [[unlikely]] {
-    return passthrough();
-  }
-
   auto ovr = OVRProxy::Get();
   const auto predictedTime
     = ovr->ovr_GetPredictedDisplayTime(session, frameIndex);
-
   const auto renderParams
     = this->GetRenderParameters(config, this->GetHMDPose(predictedTime));
+
+  if (!mRenderer->Render(session, mSwapChain, snapshot, renderParams))
+    [[unlikely]] {
+    return passthrough();
+  }
 
   ovrLayerQuad kneeboardLayer {
     .Header = { 

--- a/src/injectables/OculusKneeboard.cpp
+++ b/src/injectables/OculusKneeboard.cpp
@@ -122,13 +122,8 @@ ovrResult OculusKneeboard::OnOVREndFrame(
   const auto predictedTime
     = ovr->ovr_GetPredictedDisplayTime(session, frameIndex);
 
-  const auto& vr = config.vr;
-  const auto hmdPose = this->GetHMDPose(predictedTime);
-  const auto kneeboardPose = this->GetKneeboardPose(vr, hmdPose);
-  const auto isLookingAtKneeboard
-    = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
-  const auto kneeboardSize
-    = this->GetKneeboardSize(config, isLookingAtKneeboard);
+  const auto renderParams
+    = this->GetRenderParameters(config, this->GetHMDPose(predictedTime));
 
   ovrLayerQuad kneeboardLayer {
     .Header = { 
@@ -140,8 +135,8 @@ ovrResult OculusKneeboard::OnOVREndFrame(
       .Pos = {0, 0},
       .Size = { config.imageWidth, config.imageHeight },
     },
-    .QuadPoseCenter = GetOvrPosef(kneeboardPose),
-    .QuadSize = { kneeboardSize.x, kneeboardSize.y }
+    .QuadPoseCenter = GetOvrPosef(renderParams.mKneeboardPose),
+    .QuadSize = { renderParams.mKneeboardSize.x, renderParams.mKneeboardSize.y }
   };
 
   std::vector<const ovrLayerHeader*> newLayers;

--- a/src/injectables/OculusKneeboard.cpp
+++ b/src/injectables/OculusKneeboard.cpp
@@ -125,8 +125,10 @@ ovrResult OculusKneeboard::OnOVREndFrame(
   const auto& vr = config.vr;
   const auto hmdPose = this->GetHMDPose(predictedTime);
   const auto kneeboardPose = this->GetKneeboardPose(vr, hmdPose);
+  const auto isLookingAtKneeboard
+    = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
   const auto kneeboardSize
-    = this->GetKneeboardSize(config, hmdPose, kneeboardPose);
+    = this->GetKneeboardSize(config, isLookingAtKneeboard);
 
   ovrLayerQuad kneeboardLayer {
     .Header = { 

--- a/src/injectables/OculusKneeboard.cpp
+++ b/src/injectables/OculusKneeboard.cpp
@@ -117,11 +117,15 @@ ovrResult OculusKneeboard::OnOVREndFrame(
   const auto predictedTime
     = ovr->ovr_GetPredictedDisplayTime(session, frameIndex);
   const auto renderParams
-    = this->GetRenderParameters(config, this->GetHMDPose(predictedTime));
+    = this->GetRenderParameters(snapshot, this->GetHMDPose(predictedTime));
 
-  if (!mRenderer->Render(session, mSwapChain, snapshot, renderParams))
-    [[unlikely]] {
-    return passthrough();
+  static uint64_t sRenderKey = ~(0ui64);
+  if (sRenderKey != renderParams.mCacheKey) {
+    if (!mRenderer->Render(session, mSwapChain, snapshot, renderParams))
+      [[unlikely]] {
+      return passthrough();
+    }
+    sRenderKey = renderParams.mCacheKey;
   }
 
   ovrLayerQuad kneeboardLayer {

--- a/src/injectables/OculusKneeboard.h
+++ b/src/injectables/OculusKneeboard.h
@@ -63,7 +63,8 @@ class OculusKneeboard::Renderer {
   virtual bool Render(
     ovrSession session,
     ovrTextureSwapChain swapChain,
-    const SHM::Snapshot& snapshot)
+    const SHM::Snapshot& snapshot,
+    const VRKneeboard::RenderParameters&)
     = 0;
 };
 

--- a/src/injectables/OpenXRKneeboard.cpp
+++ b/src/injectables/OpenXRKneeboard.cpp
@@ -289,7 +289,7 @@ XrResult OpenXRD3D11Kneeboard::xrEndFrame(
 
   const auto displayTime = frameEndInfo->displayTime;
   const auto renderParams
-    = this->GetRenderParameters(config, this->GetHMDPose(displayTime));
+    = this->GetRenderParameters(snapshot, this->GetHMDPose(displayTime));
   this->Render(snapshot, renderParams);
 
   std::vector<const XrCompositionLayerBaseHeader*> nextLayers;
@@ -336,11 +336,8 @@ XrResult OpenXRD3D11Kneeboard::xrEndFrame(
 void OpenXRD3D11Kneeboard::Render(
   const SHM::Snapshot& snapshot,
   const VRKneeboard::RenderParameters& params) {
-  static uint64_t sSequenceNumber = ~(0ui64);
-  static float sOpacity = 1.0f;
-  if (
-    snapshot.GetSequenceNumber() == sSequenceNumber
-    && params.mKneeboardOpacity == sOpacity) {
+  static uint64_t sCacheKey = ~(0ui64);
+  if (params.mCacheKey == sCacheKey) {
     return;
   }
 
@@ -383,7 +380,7 @@ void OpenXRD3D11Kneeboard::Render(
   if (nextResult != XR_SUCCESS) {
     dprintf("Failed to release swapchain: {}", nextResult);
   }
-  sSequenceNumber = snapshot.GetSequenceNumber();
+  sCacheKey = params.mCacheKey;
 }
 
 // Don't use a unique_ptr as on process exit, windows doesn't clean these up

--- a/src/injectables/OpenXRKneeboard.cpp
+++ b/src/injectables/OpenXRKneeboard.cpp
@@ -285,8 +285,10 @@ XrResult OpenXRD3D11Kneeboard::xrEndFrame(
   const auto& vr = config.vr;
   const auto hmdPose = this->GetHMDPose(displayTime);
   const auto kneeboardPose = this->GetKneeboardPose(vr, hmdPose);
+  const auto isLookingAtKneeboard
+    = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
   const auto kneeboardSize
-    = this->GetKneeboardSize(config, hmdPose, kneeboardPose);
+    = this->GetKneeboardSize(config, isLookingAtKneeboard);
 
   std::vector<const XrCompositionLayerBaseHeader*> nextLayers;
   std::copy(

--- a/src/injectables/OpenXRKneeboard.cpp
+++ b/src/injectables/OpenXRKneeboard.cpp
@@ -281,14 +281,8 @@ XrResult OpenXRD3D11Kneeboard::xrEndFrame(
   auto config = snapshot.GetConfig();
 
   const auto displayTime = frameEndInfo->displayTime;
-
-  const auto& vr = config.vr;
-  const auto hmdPose = this->GetHMDPose(displayTime);
-  const auto kneeboardPose = this->GetKneeboardPose(vr, hmdPose);
-  const auto isLookingAtKneeboard
-    = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
-  const auto kneeboardSize
-    = this->GetKneeboardSize(config, isLookingAtKneeboard);
+  const auto renderParams
+    = this->GetRenderParameters(config, this->GetHMDPose(displayTime));
 
   std::vector<const XrCompositionLayerBaseHeader*> nextLayers;
   std::copy(
@@ -315,8 +309,8 @@ XrResult OpenXRD3D11Kneeboard::xrEndFrame(
       },
       .imageArrayIndex = 0,
     },
-    .pose = this->GetXrPosef(kneeboardPose),
-    .size = { kneeboardSize.x, kneeboardSize.y },
+    .pose = this->GetXrPosef(renderParams.mKneeboardPose),
+    .size = { renderParams.mKneeboardSize.x, renderParams.mKneeboardSize.y },
   };
   nextLayers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&layer));
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(
   OpenKneeboard-D3D11
   PRIVATE
   ThirdParty::DirectXTK
+  OpenKneeboard-config
 )
 
 add_library(OpenKneeboard-DXResources STATIC DXResources.cpp)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -31,6 +31,18 @@ target_link_libraries(
   ThirdParty::JSON
 )
 
+add_library(OpenKneeboard-D3D11 STATIC D3D11.cpp)
+target_link_libraries(
+  OpenKneeboard-D3D11
+  PUBLIC
+  _libheaders
+)
+target_link_libraries(
+  OpenKneeboard-D3D11
+  PRIVATE
+  ThirdParty::DirectXTK
+)
+
 add_library(OpenKneeboard-DXResources STATIC DXResources.cpp)
 target_link_libraries(OpenKneeboard-DXResources PUBLIC _libheaders)
 

--- a/src/lib/D3D11.cpp
+++ b/src/lib/D3D11.cpp
@@ -1,0 +1,49 @@
+/*
+ * OpenKneeboard
+ *
+ * Copyright (C) 2022 Fred Emmott <fred@fredemmott.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+#include <DirectXTK/SpriteBatch.h>
+#include <OpenKneeboard/D3D11.h>
+#include <shims/winrt.h>
+
+namespace OpenKneeboard::D3D11 {
+
+void CopyTextureWithTint(
+  ID3D11Device* device,
+  ID3D11ShaderResourceView* source,
+  ID3D11RenderTargetView* dest,
+  DirectX::FXMVECTOR tint) {
+  winrt::com_ptr<ID3D11DeviceContext> ctx;
+  device->GetImmediateContext(ctx.put());
+  ctx->ClearRenderTargetView(dest, DirectX::Colors::Transparent);
+  ctx->OMSetRenderTargets(1, &dest, nullptr);
+  DirectX::SpriteBatch sprites(ctx.get());
+  sprites.Begin();
+  sprites.Draw(source, DirectX::XMFLOAT2 {0.0f, 0.0f}, tint);
+  sprites.End();
+}
+
+void CopyTextureWithOpacity(
+  ID3D11Device* device,
+  ID3D11ShaderResourceView* source,
+  ID3D11RenderTargetView* dest,
+  float opacity) {
+  CopyTextureWithTint(device, source, dest, DirectX::Colors::White * opacity);
+}
+
+}// namespace OpenKneeboard::D3D11

--- a/src/lib/D3D11.cpp
+++ b/src/lib/D3D11.cpp
@@ -19,6 +19,7 @@
  */
 #include <DirectXTK/SpriteBatch.h>
 #include <OpenKneeboard/D3D11.h>
+#include <OpenKneeboard/config.h>
 #include <shims/winrt.h>
 
 namespace OpenKneeboard::D3D11 {
@@ -30,8 +31,17 @@ void CopyTextureWithTint(
   DirectX::FXMVECTOR tint) {
   winrt::com_ptr<ID3D11DeviceContext> ctx;
   device->GetImmediateContext(ctx.put());
-  ctx->ClearRenderTargetView(dest, DirectX::Colors::Transparent);
+  D3D11_VIEWPORT viewport {
+    0.0f,
+    0.0f,
+    static_cast<FLOAT>(TextureWidth),
+    static_cast<FLOAT>(TextureHeight),
+    0.0f,
+    1.0f,
+  };
+  ctx->RSSetViewports(1, &viewport);
   ctx->OMSetRenderTargets(1, &dest, nullptr);
+
   DirectX::SpriteBatch sprites(ctx.get());
   sprites.Begin();
   sprites.Draw(source, DirectX::XMFLOAT2 {0.0f, 0.0f}, tint);

--- a/src/lib/VRKneeboard.cpp
+++ b/src/lib/VRKneeboard.cpp
@@ -55,6 +55,10 @@ Vector2 VRKneeboard::GetKneeboardSize(
 }
 
 bool VRKneeboard::IsGazeEnabled(const VRRenderConfig& vr) {
+  if (std::abs(vr.mGazeOpacity - vr.mNormalOpacity) >= 0.01f) {
+    return true;
+  }
+
   if (vr.mFlags & VRRenderConfig::Flags::FORCE_ZOOM) {
     return false;
   }

--- a/src/lib/VRKneeboard.cpp
+++ b/src/lib/VRKneeboard.cpp
@@ -106,6 +106,20 @@ void VRKneeboard::Recenter(const VRRenderConfig& vr, const Pose& hmdPose) {
   mRecenterCount = vr.mRecenterCount;
 }
 
+VRKneeboard::RenderParameters VRKneeboard::GetRenderParameters(
+  const SHM::Config& config,
+  const Pose& hmdPose) {
+  const auto kneeboardPose = this->GetKneeboardPose(config.vr, hmdPose);
+  const auto isLookingAtKneeboard
+    = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
+  const auto kneeboardSize
+    = this->GetKneeboardSize(config, isLookingAtKneeboard);
+  return {
+    .mKneeboardPose = kneeboardPose,
+    .mKneeboardSize = kneeboardSize,
+  };
+}
+
 bool VRKneeboard::IsLookingAtKneeboard(
   const SHM::Config& config,
   const Pose& hmdPose,

--- a/src/lib/VRKneeboard.cpp
+++ b/src/lib/VRKneeboard.cpp
@@ -111,8 +111,9 @@ void VRKneeboard::Recenter(const VRRenderConfig& vr, const Pose& hmdPose) {
 }
 
 VRKneeboard::RenderParameters VRKneeboard::GetRenderParameters(
-  const SHM::Config& config,
+  const SHM::Snapshot& snapshot,
   const Pose& hmdPose) {
+  auto config = snapshot.GetConfig();
   const auto kneeboardPose = this->GetKneeboardPose(config.vr, hmdPose);
   const auto isLookingAtKneeboard
     = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
@@ -121,6 +122,8 @@ VRKneeboard::RenderParameters VRKneeboard::GetRenderParameters(
     .mKneeboardSize = this->GetKneeboardSize(config, isLookingAtKneeboard),
     .mKneeboardOpacity
     = isLookingAtKneeboard ? config.vr.mGazeOpacity : config.vr.mNormalOpacity,
+    .mCacheKey = snapshot.GetSequenceNumber()
+      ^ ((isLookingAtKneeboard ? 1ui64 : 0ui64) << 63),
   };
 }
 

--- a/src/lib/VRKneeboard.cpp
+++ b/src/lib/VRKneeboard.cpp
@@ -46,15 +46,12 @@ VRKneeboard::Pose VRKneeboard::GetKneeboardPose(
 
 Vector2 VRKneeboard::GetKneeboardSize(
   const SHM::Config& config,
-  const Pose& hmdPose,
-  const Pose& kneeboardPose) {
+  bool isLookingAtKneeboard) {
   const auto sizes = this->GetSizes(config);
   if (!this->IsGazeEnabled(config.vr)) {
     return sizes.mNormalSize;
   }
-  return this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose)
-    ? sizes.mZoomedSize
-    : sizes.mNormalSize;
+  return isLookingAtKneeboard ? sizes.mZoomedSize : sizes.mNormalSize;
 }
 
 bool VRKneeboard::IsGazeEnabled(const VRRenderConfig& vr) {

--- a/src/lib/VRKneeboard.cpp
+++ b/src/lib/VRKneeboard.cpp
@@ -112,11 +112,11 @@ VRKneeboard::RenderParameters VRKneeboard::GetRenderParameters(
   const auto kneeboardPose = this->GetKneeboardPose(config.vr, hmdPose);
   const auto isLookingAtKneeboard
     = this->IsLookingAtKneeboard(config, hmdPose, kneeboardPose);
-  const auto kneeboardSize
-    = this->GetKneeboardSize(config, isLookingAtKneeboard);
   return {
     .mKneeboardPose = kneeboardPose,
-    .mKneeboardSize = kneeboardSize,
+    .mKneeboardSize = this->GetKneeboardSize(config, isLookingAtKneeboard),
+    .mKneeboardOpacity
+    = isLookingAtKneeboard ? config.vr.mGazeOpacity : config.vr.mNormalOpacity,
   };
 }
 

--- a/src/lib/include/OpenKneeboard/D3D11.h
+++ b/src/lib/include/OpenKneeboard/D3D11.h
@@ -1,0 +1,39 @@
+/*
+ * OpenKneeboard
+ *
+ * Copyright (C) 2022 Fred Emmott <fred@fredemmott.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+#pragma once
+
+#include <DirectXMath.h>
+#include <d3d11.h>
+
+namespace OpenKneeboard::D3D11 {
+
+void CopyTextureWithTint(
+  ID3D11Device* device,
+  ID3D11ShaderResourceView* source,
+  ID3D11RenderTargetView* dest,
+  DirectX::FXMVECTOR tint);
+
+void CopyTextureWithOpacity(
+  ID3D11Device* device,
+  ID3D11ShaderResourceView* source,
+  ID3D11RenderTargetView* dest,
+  float opacity);
+
+}// namespace OpenKneeboard::D3D11

--- a/src/lib/include/OpenKneeboard/SHM.h
+++ b/src/lib/include/OpenKneeboard/SHM.h
@@ -77,31 +77,38 @@ class Writer final {
   std::shared_ptr<Impl> p;
 };
 
+struct TextureReadResources;
+
 class SharedTexture final {
  public:
   SharedTexture();
-  SharedTexture(const Header& header, ID3D11Device* d3d);
+  SharedTexture(
+    const Header& header,
+    ID3D11Device* d3d,
+    TextureReadResources* r);
   ~SharedTexture();
 
   operator bool() const;
   ID3D11Texture2D* GetTexture() const;
   IDXGISurface* GetSurface() const;
+  ID3D11ShaderResourceView* GetShaderResourceView() const;
 
   SharedTexture(const SharedTexture&) = delete;
   SharedTexture(SharedTexture&&) = delete;
 
  private:
   UINT mKey = 0;
-  winrt::com_ptr<ID3D11Texture2D> mTexture;
+  TextureReadResources* mResources = nullptr;
 };
 
 class Snapshot final {
  private:
   std::unique_ptr<Header> mHeader;
+  TextureReadResources* mResources;
 
  public:
   Snapshot();
-  Snapshot(const Header& header);
+  Snapshot(const Header& header, TextureReadResources*);
   ~Snapshot();
 
   uint32_t GetSequenceNumber() const;
@@ -121,6 +128,7 @@ class Reader final {
   uint32_t GetSequenceNumber() const;
 
  private:
+  class Impl;
   std::shared_ptr<Impl> p;
 };
 

--- a/src/lib/include/OpenKneeboard/VRConfig.h
+++ b/src/lib/include/OpenKneeboard/VRConfig.h
@@ -60,8 +60,8 @@ struct VRRenderConfig {
     static_cast<uint32_t>(Flags::DISCARD_DEPTH_INFORMATION)
     | static_cast<uint32_t>(Flags::GAZE_ZOOM));
 
-  float mNormalOpacity = 0.1f;
-  float mGazeOpacity = 0.5f;
+  float mNormalOpacity = 1.0f;
+  float mGazeOpacity = 1.0f;
 };
 #pragma pack(pop)
 

--- a/src/lib/include/OpenKneeboard/VRConfig.h
+++ b/src/lib/include/OpenKneeboard/VRConfig.h
@@ -33,7 +33,7 @@ namespace OpenKneeboard {
 
 #pragma pack(push)
 struct VRRenderConfig {
-  static constexpr uint16_t VERSION = 3;
+  static constexpr uint16_t VERSION = 4;
 
   enum class Flags : uint32_t {
     // HEADLOCKED = 1 << 0,
@@ -59,6 +59,9 @@ struct VRRenderConfig {
   Flags mFlags = static_cast<Flags>(
     static_cast<uint32_t>(Flags::DISCARD_DEPTH_INFORMATION)
     | static_cast<uint32_t>(Flags::GAZE_ZOOM));
+
+  float mNormalOpacity = 0.1f;
+  float mGazeOpacity = 0.5f;
 };
 #pragma pack(pop)
 

--- a/src/lib/include/OpenKneeboard/VRKneeboard.h
+++ b/src/lib/include/OpenKneeboard/VRKneeboard.h
@@ -41,6 +41,7 @@ class VRKneeboard {
     Pose mKneeboardPose;
     Vector2 mKneeboardSize;
     float mKneeboardOpacity;
+    uint64_t mCacheKey;
   };
 
  protected:
@@ -51,7 +52,9 @@ class VRKneeboard {
 
   virtual YOrigin GetYOrigin() = 0;
 
-  RenderParameters GetRenderParameters(const SHM::Config&, const Pose& hmdPose);
+  RenderParameters GetRenderParameters(
+    const SHM::Snapshot&,
+    const Pose& hmdPose);
 
  private:
   struct Sizes {

--- a/src/lib/include/OpenKneeboard/VRKneeboard.h
+++ b/src/lib/include/OpenKneeboard/VRKneeboard.h
@@ -26,7 +26,7 @@
 namespace OpenKneeboard {
 
 class VRKneeboard {
- protected:
+ public:
   using Matrix = DirectX::SimpleMath::Matrix;
   using Quaternion = DirectX::SimpleMath::Quaternion;
   using Vector2 = DirectX::SimpleMath::Vector2;
@@ -37,17 +37,19 @@ class VRKneeboard {
     Quaternion mOrientation {};
   };
 
+  struct RenderParameters {
+    Pose mKneeboardPose;
+    Vector2 mKneeboardSize;
+    float mKneeboardOpacity;
+  };
+
+ protected:
   enum class YOrigin {
     FLOOR_LEVEL,
     EYE_LEVEL,
   };
 
   virtual YOrigin GetYOrigin() = 0;
-
-  struct RenderParameters {
-    Pose mKneeboardPose;
-    Vector2 mKneeboardSize;
-  };
 
   RenderParameters GetRenderParameters(const SHM::Config&, const Pose& hmdPose);
 

--- a/src/lib/include/OpenKneeboard/VRKneeboard.h
+++ b/src/lib/include/OpenKneeboard/VRKneeboard.h
@@ -53,6 +53,10 @@ class VRKneeboard {
 
   Vector2 GetKneeboardSize(
     const SHM::Config& config,
+    bool isLookingAtKneeboard);
+
+  bool IsLookingAtKneeboard(
+    const SHM::Config& config,
     const Pose& hmdPose,
     const Pose& kneeboardPose);
 
@@ -64,11 +68,6 @@ class VRKneeboard {
   Sizes GetSizes(const SHM::Config& config) const;
 
   void Recenter(const VRRenderConfig& vr, const Pose& hmdPose);
-
-  bool IsLookingAtKneeboard(
-    const SHM::Config& config,
-    const Pose& hmdPose,
-    const Pose& kneeboardPose);
 };
 
 }// namespace OpenKneeboard

--- a/src/lib/include/OpenKneeboard/VRKneeboard.h
+++ b/src/lib/include/OpenKneeboard/VRKneeboard.h
@@ -37,17 +37,28 @@ class VRKneeboard {
     Quaternion mOrientation {};
   };
 
-  struct Sizes {
-    Vector2 mNormalSize;
-    Vector2 mZoomedSize;
-  };
-
   enum class YOrigin {
     FLOOR_LEVEL,
     EYE_LEVEL,
   };
 
   virtual YOrigin GetYOrigin() = 0;
+
+  struct RenderParameters {
+    Pose mKneeboardPose;
+    Vector2 mKneeboardSize;
+  };
+
+  RenderParameters GetRenderParameters(const SHM::Config&, const Pose& hmdPose);
+
+ private:
+  struct Sizes {
+    Vector2 mNormalSize;
+    Vector2 mZoomedSize;
+  };
+
+  uint64_t mRecenterCount = 0;
+  Matrix mRecenter = Matrix::Identity;
 
   Pose GetKneeboardPose(const VRRenderConfig& vr, const Pose& hmdPose);
 
@@ -59,10 +70,6 @@ class VRKneeboard {
     const SHM::Config& config,
     const Pose& hmdPose,
     const Pose& kneeboardPose);
-
- private:
-  uint64_t mRecenterCount = 0;
-  Matrix mRecenter = Matrix::Identity;
 
   bool IsGazeEnabled(const VRRenderConfig& vr);
   Sizes GetSizes(const SHM::Config& config) const;


### PR DESCRIPTION
Adds VR opacity settings - distinct settings for normal and gaze.

Not sure this level of flexibility is required, but 'invisible unless looking at knee' (i.e. 0% opacity) is understandable.

- Make isLookingAtKneeboard accessible to subclasses
- Refactor out common code for all VR renderers
- Add Oculus-D3D11 support for configurable transparency
- OpenXR: support variable opacity
- SteamVR: add support for variable opacity
- Reset default VR opacity values back to 1.0
- Add opacity to JSON config
- Add UI for opacity
