### PR TITLE
Fix openxr kneeboard not refreshing after process restart

### DIFF
--- a/src/injectables/OpenXRKneeboard.cpp
+++ b/src/injectables/OpenXRKneeboard.cpp
@@ -368,6 +368,10 @@ void OpenXRD3D11Kneeboard::Render(
     auto sharedTexture = snapshot.GetSharedTexture(mDevice);
     if (!sharedTexture) {
       dprint("Failed to get shared texture");
+      nextResult = gNext.xrReleaseSwapchainImage(mSwapchain, nullptr);
+      if (nextResult != XR_SUCCESS) {
+        dprintf("Failed to release swapchain image: {}", nextResult);
+      }
       return;
     }
     D3D11::CopyTextureWithOpacity(


### PR DESCRIPTION
New shared texture needed to be captured by forcing a TextureReadResources populate if the process is restarted.