### PR TITLE
Persist bookmarks across restarts

### DIFF
--- a/src/app/app-common/Tab/TabBase.cpp
+++ b/src/app/app-common/Tab/TabBase.cpp
@@ -61,11 +61,52 @@ void TabBase::SetBookmarks(const std::vector<Bookmark>& bookmarks) {
   mBookmarks = bookmarks;
   evAvailableFeaturesChangedEvent.Emit();
   evBookmarksChangedEvent.Emit();
+  evSettingsChangedEvent.Emit();
+}
+
+void TabBase::SetPendingBookmarkRestore(
+  std::vector<std::pair<PageIndex, std::string>> pending) {
+  const auto pageIDs = this->GetPageIDs();
+  if (!pageIDs.empty()) {
+    // Content already loaded (e.g. folder scan completed before we were called):
+    // apply immediately instead of waiting for evContentChangedEvent.
+    std::vector<Bookmark> restored;
+    for (const auto& [pageIndex, title]: pending) {
+      if (pageIndex < pageIDs.size()) {
+        restored.push_back({mRuntimeID, pageIDs[pageIndex], title});
+      }
+    }
+    // Event listeners are not set up yet at this point, so emitting events
+    // here is safe and harmless.
+    this->SetBookmarks(restored);
+    return;
+  }
+  mPendingBookmarks = std::move(pending);
+}
+
+std::vector<std::pair<PageIndex, std::string>>
+TabBase::GetPendingBookmarkData() const {
+  return mPendingBookmarks;
 }
 
 void TabBase::OnContentChanged() {
-  decltype(mBookmarks) bookmarks;
   const auto pageIDs = this->GetPageIDs();
+
+  if (!mPendingBookmarks.empty()) {
+    if (!pageIDs.empty()) {
+      std::vector<Bookmark> restored;
+      for (const auto& [pageIndex, title]: mPendingBookmarks) {
+        if (pageIndex < pageIDs.size()) {
+          restored.push_back({mRuntimeID, pageIDs[pageIndex], title});
+        }
+      }
+      mPendingBookmarks.clear();
+      this->SetBookmarks(restored);
+    }
+    return;
+  }
+
+  decltype(mBookmarks) bookmarks;
   for (const auto& bookmark: mBookmarks) {
     if (std::ranges::find(pageIDs, bookmark.mPageID) != pageIDs.end()) {
       bookmarks.push_back(bookmark);

--- a/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
+++ b/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
@@ -25,6 +25,13 @@ class TabBase : public virtual ITab, public virtual EventReceiver {
   virtual std::vector<Bookmark> GetBookmarks() const override final;
   virtual void SetBookmarks(const std::vector<Bookmark>&) override final;
 
+  void SetPendingBookmarkRestore(
+    std::vector<std::pair<PageIndex, std::string>> pending);
+
+  // Returns pending bookmark data for serialization during startup,
+  // before content is loaded and pending bookmarks have been applied.
+  std::vector<std::pair<PageIndex, std::string>> GetPendingBookmarkData() const;
+
  protected:
   TabBase(const winrt::guid& persistentID, std::string_view title);
 
@@ -33,6 +40,7 @@ class TabBase : public virtual ITab, public virtual EventReceiver {
   const RuntimeID mRuntimeID;
   std::string mTitle;
   std::vector<Bookmark> mBookmarks;
+  std::vector<std::pair<PageIndex, std::string>> mPendingBookmarks;
 
   void OnContentChanged();
 };

--- a/src/app/app-common/TabsList/TabsList.cpp
+++ b/src/app/app-common/TabsList/TabsList.cpp
@@ -73,21 +73,21 @@ task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
     // else handled by TabBase
   }
 
+  std::shared_ptr<ITab> result;
   try {
 #define IT(_, it) \
   if (type == #it) { \
     auto instance = co_await load_tab<it##Tab>( \
       mDXR, mKneeboard, persistentID, title, settings); \
     if (instance) { \
-      co_return instance; \
+      result = instance; \
     } \
   }
     OPENKNEEBOARD_TAB_TYPES
 #undef IT
-    if (type == "Plugin") {
-      auto instance = co_await PluginTab::Create(
+    if (!result && type == "Plugin") {
+      result = co_await PluginTab::Create(
         mDXR, mKneeboard, persistentID, title, settings);
-      co_return instance;
     }
   } catch (const std::exception& e) {
     dprint.Error(
@@ -102,9 +102,31 @@ task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
       winrt::to_string(e.message()));
     throw;
   }
-  dprint("Couldn't load tab with type {}", rawType);
-  OPENKNEEBOARD_BREAK;
-  co_return nullptr;
+
+  if (!result) {
+    dprint("Couldn't load tab with type {}", rawType);
+    OPENKNEEBOARD_BREAK;
+    co_return nullptr;
+  }
+
+  if (tab.contains("Bookmarks")) {
+    std::vector<std::pair<PageIndex, std::string>> pending;
+    for (const auto& entry: tab.at("Bookmarks")) {
+      if (!entry.contains("PageIndex") || !entry.contains("Title")) {
+        continue;
+      }
+      pending.emplace_back(
+        entry.at("PageIndex").get<PageIndex>(),
+        entry.at("Title").get<std::string>());
+    }
+    if (!pending.empty()) {
+      if (auto tabBase = std::dynamic_pointer_cast<TabBase>(result)) {
+        tabBase->SetPendingBookmarkRestore(std::move(pending));
+      }
+    }
+  }
+
+  co_return result;
 }
 
 task<void> TabsList::LoadSettings(nlohmann::json config) {
@@ -187,6 +209,42 @@ nlohmann::json TabsList::GetSettings() const {
         savedTab.emplace("Settings", settings);
       }
     }
+
+    {
+      nlohmann::json bookmarkArray = nlohmann::json::array();
+      const auto liveBookmarks = tab->GetBookmarks();
+
+      if (!liveBookmarks.empty()) {
+        // Content is loaded: serialize live bookmarks as page indices.
+        const auto pageIDs = tab->GetPageIDs();
+        for (const auto& bookmark: liveBookmarks) {
+          const auto it = std::ranges::find(pageIDs, bookmark.mPageID);
+          if (it == pageIDs.end()) {
+            continue;
+          }
+          bookmarkArray.push_back({
+            {"PageIndex",
+             static_cast<PageIndex>(
+               std::distance(pageIDs.begin(), it))},
+            {"Title", bookmark.mTitle},
+          });
+        }
+      } else if (const auto tabBase = std::dynamic_pointer_cast<TabBase>(tab)) {
+        // Content not yet loaded (pending restore phase): pass pending data
+        // through so the startup save does not clobber the bookmark data.
+        for (const auto& [pageIndex, title]: tabBase->GetPendingBookmarkData()) {
+          bookmarkArray.push_back({
+            {"PageIndex", pageIndex},
+            {"Title", title},
+          });
+        }
+      }
+
+      if (!bookmarkArray.empty()) {
+        savedTab.emplace("Bookmarks", std::move(bookmarkArray));
+      }
+    }
+
     ret.push_back(savedTab);
     continue;
   }


### PR DESCRIPTION
Save bookmarks as page indices in Tabs.json and restore them on load. Handles the race where content finishes loading before or after SetPendingBookmarkRestore() is called, and guards against the startup save clobbering pending bookmark data before content is available.

close #253 