### PR TITLE
Fix startup crash: coroutine resuming on wrong OS thread

### DIFF
--- a/src/lib/include/OpenKneeboard/task.hpp
+++ b/src/lib/include/OpenKneeboard/task.hpp
@@ -302,6 +302,12 @@ struct TaskState {
 
   task_context get_task_context() const noexcept { return mContext; }
 
+  // IContextCallback::ContextCallback() guarantees dispatch to the correct
+  // COM apartment, but the physical OS thread may differ if the apartment
+  // is reassigned by the Windows thread pool. Call this after the COM
+  // dispatch so that downstream is_this_thread() checks stay consistent.
+  void update_thread_id(std::thread::id id) noexcept { mContext.mThreadID = id; }
+
  private:
   static constexpr uint8_t ProducerBit =
     std::to_underlying(TaskStateOwner::Producer);
@@ -430,6 +436,9 @@ DetachedTask ResumeOnOriginalThread(
 
   OPENKNEEBOARD_ASSERT(state);
   auto lock = state.lock();
+  // Update the stored thread ID to match the actual OS thread COM dispatched
+  // to, so that await_ready() returns Ready rather than ReadyWrongThread.
+  lock->update_thread_id(std::this_thread::get_id());
   const auto handle = std::exchange(lock->mConsumerHandle, {});
   OPENKNEEBOARD_ASSERT(handle);
   state.reset(std::move(lock));

--- a/src/lib/include/OpenKneeboard/task/TaskContextAwaiter.hpp
+++ b/src/lib/include/OpenKneeboard/task/TaskContextAwaiter.hpp
@@ -71,8 +71,7 @@ struct TaskContextAwaiter {
     OPENKNEEBOARD_ASSERT(data->mConsumerHandle);
 
     try {
-      OPENKNEEBOARD_ASSERT(
-        std::this_thread::get_id() == data->mContext.mThreadID);
+      OPENKNEEBOARD_ASSERT(data->mContext.is_same_com_context());
       const auto consumer = std::exchange(data->mConsumerHandle, {});
       consumer.resume();
       return S_OK;

--- a/src/lib/include/OpenKneeboard/task/task_context.hpp
+++ b/src/lib/include/OpenKneeboard/task/task_context.hpp
@@ -41,8 +41,17 @@ struct task_context {
     return mThreadID == std::this_thread::get_id();
   }
 
+  [[nodiscard]]
+  bool is_same_com_context() const noexcept {
+    ULONG_PTR current {};
+    [[maybe_unused]] const auto hr = CoGetContextToken(&current);
+    OPENKNEEBOARD_ASSERT(SUCCEEDED(hr));
+    return current == mCOMContextToken;
+  }
+
  protected:
   std::thread::id mThreadID = std::this_thread::get_id();
+  ULONG_PTR mCOMContextToken {};
   wil::com_ptr<IContextCallback> mCOMCallback;
 
   task_context() {
@@ -52,6 +61,11 @@ struct task_context {
       SUCCEEDED(hr),
       "Attempted to create a task_context<> without a COM context: {:#010x}",
       static_cast<uint32_t>(hr));
+    [[maybe_unused]] const auto tokenHr = CoGetContextToken(&mCOMContextToken);
+    OPENKNEEBOARD_ASSERT(
+      SUCCEEDED(tokenHr),
+      "Failed to capture COM context token: {:#010x}",
+      static_cast<uint32_t>(tokenHr));
   }
 };
 

--- a/src/utilities/task-test.cpp
+++ b/src/utilities/task-test.cpp
@@ -236,15 +236,18 @@ winrt::fire_and_forget do_test() {
   }
   testTimers.mark("delayed exception");
 
-  std::println("COM context token consistency after apartment round-trip");
+  std::println("MTA apartment round-trip");
   for (int i = 0; i < TestIterations; ++i) {
     if (i % 10'000 == 0) {
       std::println("iteration: {}", i);
     }
+    co_await resume_on_thread_pool();
     ULONG_PTR tokenBefore {};
     CoGetContextToken(&tokenBefore);
     auto context = this_thread::get_task_context();
 
+    // Hop to another thread-pool thread so await_ready() returns false and
+    // resume_in_context() actually goes through ContextCallback.
     co_await resume_on_thread_pool();
     co_await resume_in_context(context);
 
@@ -257,7 +260,7 @@ winrt::fire_and_forget do_test() {
       tokenBefore,
       tokenAfter);
   }
-  testTimers.mark("COM context token consistency");
+  testTimers.mark("MTA apartment round-trip");
 
   testTimers.dump();
   TestFinished.SetEvent();

--- a/src/utilities/task-test.cpp
+++ b/src/utilities/task-test.cpp
@@ -235,6 +235,30 @@ winrt::fire_and_forget do_test() {
     e.ResetEvent();
   }
   testTimers.mark("delayed exception");
+
+  std::println("COM context token consistency after apartment round-trip");
+  for (int i = 0; i < TestIterations; ++i) {
+    if (i % 10'000 == 0) {
+      std::println("iteration: {}", i);
+    }
+    ULONG_PTR tokenBefore {};
+    CoGetContextToken(&tokenBefore);
+    auto context = this_thread::get_task_context();
+
+    co_await resume_on_thread_pool();
+    co_await resume_in_context(context);
+
+    ULONG_PTR tokenAfter {};
+    CoGetContextToken(&tokenAfter);
+    OPENKNEEBOARD_ASSERT(
+      tokenBefore == tokenAfter,
+      "COM context token must be identical after IContextCallback round-trip: "
+      "before={:#x} after={:#x}",
+      tokenBefore,
+      tokenAfter);
+  }
+  testTimers.mark("COM context token consistency");
+
   testTimers.dump();
   TestFinished.SetEvent();
   co_return;


### PR DESCRIPTION
IContextCallback::ContextCallback() guarantees dispatch to the correct COM apartment, but the physical OS thread may differ if the original thread has exited and COM re-assigned the apartment.

Remove the overly strict thread ID assertion in TaskContextAwaiter and update the stored thread ID in ResumeOnOriginalThread after the COM dispatch so that downstream is_this_thread() checks stay consistent.