### PR TITLE
feat: persist bookmarks across restarts for SingleFile and Folder tabs 

### DIFF
--- a/src/app/app-common/CMakeLists.txt
+++ b/src/app/app-common/CMakeLists.txt
@@ -89,6 +89,7 @@ ok_add_library(
   PageSource/ChromiumPageSource_Client.hpp
   PageSource/ChromiumPageSource_RenderHandler.cpp
   PageSource/ChromiumPageSource_RenderHandler.hpp
+  PageSource/FileHash.cpp
   PageSource/FilePageSource.cpp
   PageSource/FolderPageSource.cpp
   PageSource/HWNDPageSource.cpp
@@ -99,6 +100,7 @@ ok_add_library(
   PageSource/PlainTextFilePageSource.cpp
   PageSource/PlainTextPageSource.cpp
   PageSource/include/OpenKneeboard/ChromiumPageSource.hpp
+  PageSource/include/OpenKneeboard/FileHash.hpp
   PageSource/include/OpenKneeboard/FilePageSource.hpp
   PageSource/include/OpenKneeboard/FolderPageSource.hpp
   PageSource/include/OpenKneeboard/HWNDPageSource.hpp

--- a/src/app/app-common/PageSource/FileHash.cpp
+++ b/src/app/app-common/PageSource/FileHash.cpp
@@ -1,0 +1,54 @@
+// OpenKneeboard
+//
+// Copyright (c) 2025 Fred Emmott <fred@fredemmott.com>
+//
+// This program is open source; see the LICENSE file in the root of the
+// OpenKneeboard repository.
+#include <OpenKneeboard/FileHash.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <vector>
+
+namespace OpenKneeboard {
+
+std::expected<uint64_t, std::error_code> PartialFileHash(
+  const std::filesystem::path& path) noexcept {
+  std::error_code ec;
+  const auto size = std::filesystem::file_size(path, ec);
+  if (ec) {
+    return std::unexpected(ec);
+  }
+
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    return std::unexpected(
+      std::make_error_code(std::errc::no_such_file_or_directory));
+  }
+
+  constexpr std::uintmax_t kMaxRead = 65536;
+  const auto readSize
+    = static_cast<std::streamsize>(std::min<std::uintmax_t>(size, kMaxRead));
+  std::vector<char> buf(readSize);
+  if (readSize > 0) {
+    file.read(buf.data(), readSize);
+  }
+  const auto n = static_cast<std::size_t>(file.gcount());
+
+  constexpr uint64_t kFNVOffsetBasis = 14695981039346656037ULL;
+  constexpr uint64_t kFNVPrime = 1099511628211ULL;
+  uint64_t hash = kFNVOffsetBasis;
+  for (std::size_t i = 0; i < n; ++i) {
+    hash ^= static_cast<uint8_t>(buf[i]);
+    hash *= kFNVPrime;
+  }
+  // Also mix in the file size to distinguish files with identical prefixes.
+  const auto* sizeBytes = reinterpret_cast<const uint8_t*>(&size);
+  for (std::size_t i = 0; i < sizeof(size); ++i) {
+    hash ^= sizeBytes[i];
+    hash *= kFNVPrime;
+  }
+  return hash;
+}
+
+}// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/FolderPageSource.cpp
+++ b/src/app/app-common/PageSource/FolderPageSource.cpp
@@ -127,4 +127,32 @@ task<void> FolderPageSource::SetPath(std::filesystem::path path) {
   co_await this->Reload();
 }
 
+std::optional<std::pair<std::filesystem::path, PageIndex>>
+FolderPageSource::GetFileAndLocalIndexForPageID(PageID id) const {
+  for (const auto& [absPath, info]: mContents) {
+    const auto pageIDs = info.mDelegate->GetPageIDs();
+    for (PageIndex i = 0; i < static_cast<PageIndex>(pageIDs.size()); ++i) {
+      if (pageIDs[i] == id) {
+        return std::make_pair(absPath.lexically_relative(mPath), i);
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<PageID> FolderPageSource::GetPageIDForRelativeFile(
+  const std::filesystem::path& relativeFile,
+  PageIndex localIndex) const {
+  const auto full = (mPath / relativeFile).lexically_normal();
+  const auto it = mContents.find(full);
+  if (it == mContents.end()) {
+    return std::nullopt;
+  }
+  const auto pageIDs = it->second.mDelegate->GetPageIDs();
+  if (localIndex >= static_cast<PageIndex>(pageIDs.size())) {
+    return std::nullopt;
+  }
+  return pageIDs[localIndex];
+}
+
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/FolderPageSource.cpp
+++ b/src/app/app-common/PageSource/FolderPageSource.cpp
@@ -4,13 +4,10 @@
 //
 // This program is open source; see the LICENSE file in the root of the
 // OpenKneeboard repository.
-#include <OpenKneeboard/FileHash.hpp>
 #include <OpenKneeboard/FilePageSource.hpp>
 #include <OpenKneeboard/FolderPageSource.hpp>
 
 #include <OpenKneeboard/dprint.hpp>
-
-#include <shims/nlohmann/json.hpp>
 
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
@@ -126,73 +123,6 @@ task<void> FolderPageSource::SetPath(std::filesystem::path path) {
   mPath = path;
   mWatcher = {};
   co_await this->Reload();
-}
-
-std::optional<std::pair<std::filesystem::path, PageIndex>>
-FolderPageSource::GetFileAndLocalIndexForPageID(PageID id) const {
-  for (const auto& [absPath, info]: mContents) {
-    const auto pageIDs = info.mDelegate->GetPageIDs();
-    for (PageIndex i = 0; i < static_cast<PageIndex>(pageIDs.size()); ++i) {
-      if (pageIDs[i] == id) {
-        return std::make_pair(absPath.lexically_relative(mPath), i);
-      }
-    }
-  }
-  return std::nullopt;
-}
-
-std::optional<PageID> FolderPageSource::GetPageIDForRelativeFile(
-  const std::filesystem::path& relativeFile,
-  PageIndex localIndex) const {
-  const auto full = (mPath / relativeFile).lexically_normal();
-  const auto it = mContents.find(full);
-  if (it == mContents.end()) {
-    return std::nullopt;
-  }
-  const auto pageIDs = it->second.mDelegate->GetPageIDs();
-  if (localIndex >= static_cast<PageIndex>(pageIDs.size())) {
-    return std::nullopt;
-  }
-  return pageIDs[localIndex];
-}
-
-std::optional<nlohmann::json> FolderPageSource::GetPersistentIDForPage(
-  PageID id) const {
-  const auto info = this->GetFileAndLocalIndexForPageID(id);
-  if (!info) {
-    return std::nullopt;
-  }
-  const auto absFile = mPath / info->first;
-  const auto hash = ComputeFileHash(absFile);
-  if (!hash) {
-    return std::nullopt;
-  }
-  return nlohmann::json {
-    {"File", info->first.generic_string()},
-    {"FileHash", hash},
-    {"LocalPageIndex", info->second},
-  };
-}
-
-std::optional<PageID> FolderPageSource::GetPageIDFromPersistentID(
-  const nlohmann::json& id) const {
-  if (!id.contains("File") || !id.contains("FileHash")
-      || !id.contains("LocalPageIndex")) {
-    return std::nullopt;
-  }
-  const std::filesystem::path relFile {id.at("File").get<std::string>()};
-  const auto storedHash = id.at("FileHash").get<uint64_t>();
-  const auto absFile = mPath / relFile;
-  std::error_code ec;
-  if (!std::filesystem::exists(absFile, ec) || ec) {
-    return std::nullopt;
-  }
-  const auto currentHash = ComputeFileHash(absFile);
-  if (!currentHash || currentHash != storedHash) {
-    return std::nullopt;
-  }
-  return this->GetPageIDForRelativeFile(
-    relFile, id.at("LocalPageIndex").get<PageIndex>());
 }
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/FolderPageSource.cpp
+++ b/src/app/app-common/PageSource/FolderPageSource.cpp
@@ -4,6 +4,7 @@
 //
 // This program is open source; see the LICENSE file in the root of the
 // OpenKneeboard repository.
+#include <OpenKneeboard/FileHash.hpp>
 #include <OpenKneeboard/FilePageSource.hpp>
 #include <OpenKneeboard/FolderPageSource.hpp>
 
@@ -153,6 +154,45 @@ std::optional<PageID> FolderPageSource::GetPageIDForRelativeFile(
     return std::nullopt;
   }
   return pageIDs[localIndex];
+}
+
+std::optional<nlohmann::json> FolderPageSource::GetPersistentIDForPage(
+  PageID id) const {
+  const auto info = this->GetFileAndLocalIndexForPageID(id);
+  if (!info) {
+    return std::nullopt;
+  }
+  const auto absFile = mPath / info->first;
+  const auto hash = ComputeFileHash(absFile);
+  if (!hash) {
+    return std::nullopt;
+  }
+  return nlohmann::json {
+    {"File", info->first.generic_string()},
+    {"FileHash", hash},
+    {"LocalPageIndex", info->second},
+  };
+}
+
+std::optional<PageID> FolderPageSource::GetPageIDFromPersistentID(
+  const nlohmann::json& id) const {
+  if (!id.contains("File") || !id.contains("FileHash")
+      || !id.contains("LocalPageIndex")) {
+    return std::nullopt;
+  }
+  const std::filesystem::path relFile {id.at("File").get<std::string>()};
+  const auto storedHash = id.at("FileHash").get<uint64_t>();
+  const auto absFile = mPath / relFile;
+  std::error_code ec;
+  if (!std::filesystem::exists(absFile, ec) || ec) {
+    return std::nullopt;
+  }
+  const auto currentHash = ComputeFileHash(absFile);
+  if (!currentHash || currentHash != storedHash) {
+    return std::nullopt;
+  }
+  return this->GetPageIDForRelativeFile(
+    relFile, id.at("LocalPageIndex").get<PageIndex>());
 }
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/IPageSource.cpp
+++ b/src/app/app-common/PageSource/IPageSource.cpp
@@ -10,12 +10,12 @@ namespace OpenKneeboard {
 
 IPageSource::~IPageSource() = default;
 
-std::optional<nlohmann::json> IPageSource::GetPersistentIDForPage(PageID) const {
+std::optional<std::string> IPageSource::GetPersistentIDForPage(PageID) const {
   return std::nullopt;
 }
 
 std::optional<PageID> IPageSource::GetPageIDFromPersistentID(
-  const nlohmann::json&) const {
+  std::string_view) const {
   return std::nullopt;
 }
 

--- a/src/app/app-common/PageSource/IPageSource.cpp
+++ b/src/app/app-common/PageSource/IPageSource.cpp
@@ -10,4 +10,13 @@ namespace OpenKneeboard {
 
 IPageSource::~IPageSource() = default;
 
+std::optional<nlohmann::json> IPageSource::GetPersistentIDForPage(PageID) const {
+  return std::nullopt;
+}
+
+std::optional<PageID> IPageSource::GetPageIDFromPersistentID(
+  const nlohmann::json&) const {
+  return std::nullopt;
+}
+
 }

--- a/src/app/app-common/PageSource/ImageFilePageSource.cpp
+++ b/src/app/app-common/PageSource/ImageFilePageSource.cpp
@@ -11,6 +11,8 @@
 #include <OpenKneeboard/format/filesystem.hpp>
 #include <OpenKneeboard/scope_exit.hpp>
 
+#include <shims/nlohmann/json.hpp>
+
 #include <winrt/Windows.Foundation.h>
 
 #include <expected>
@@ -433,32 +435,34 @@ std::vector<NavigationEntry> ImageFilePageSource::GetNavigationEntries() const {
   return entries;
 }
 
-std::optional<nlohmann::json> ImageFilePageSource::GetPersistentIDForPage(
+std::optional<std::string> ImageFilePageSource::GetPersistentIDForPage(
   PageID id) const {
   for (PageIndex i = 0; i < static_cast<PageIndex>(mPages.size()); ++i) {
     if (mPages[i].mID == id) {
-      const auto hash = ComputeFileHash(mPages[i].mPath);
+      const auto hash = PartialFileHash(mPages[i].mPath);
       if (!hash) {
         return std::nullopt;
       }
-      return nlohmann::json {{"PageIndex", i}, {"FileHash", hash}};
+      return nlohmann::json {{"PageIndex", i}, {"FileHash", *hash}}.dump();
     }
   }
   return std::nullopt;
 }
 
 std::optional<PageID> ImageFilePageSource::GetPageIDFromPersistentID(
-  const nlohmann::json& id) const {
-  if (!id.contains("PageIndex") || !id.contains("FileHash")) {
+  std::string_view id) const {
+  const auto parsed = nlohmann::json::parse(id, nullptr, false);
+  if (parsed.is_discarded() || !parsed.contains("PageIndex")
+      || !parsed.contains("FileHash")) {
     return std::nullopt;
   }
-  const auto pageIndex = id.at("PageIndex").get<PageIndex>();
-  const auto storedHash = id.at("FileHash").get<uint64_t>();
+  const auto pageIndex = parsed.at("PageIndex").get<PageIndex>();
+  const auto storedHash = parsed.at("FileHash").get<uint64_t>();
   if (pageIndex >= static_cast<PageIndex>(mPages.size())) {
     return std::nullopt;
   }
-  const auto currentHash = ComputeFileHash(mPages[pageIndex].mPath);
-  if (!currentHash || currentHash != storedHash) {
+  const auto currentHash = PartialFileHash(mPages[pageIndex].mPath);
+  if (!currentHash || *currentHash != storedHash) {
     return std::nullopt;
   }
   return mPages[pageIndex].mID;

--- a/src/app/app-common/PageSource/ImageFilePageSource.cpp
+++ b/src/app/app-common/PageSource/ImageFilePageSource.cpp
@@ -4,6 +4,7 @@
 //
 // This program is open source; see the LICENSE file in the root of the
 // OpenKneeboard repository.
+#include <OpenKneeboard/FileHash.hpp>
 #include <OpenKneeboard/ImageFilePageSource.hpp>
 
 #include <OpenKneeboard/dprint.hpp>
@@ -431,4 +432,36 @@ std::vector<NavigationEntry> ImageFilePageSource::GetNavigationEntries() const {
   }
   return entries;
 }
+
+std::optional<nlohmann::json> ImageFilePageSource::GetPersistentIDForPage(
+  PageID id) const {
+  for (PageIndex i = 0; i < static_cast<PageIndex>(mPages.size()); ++i) {
+    if (mPages[i].mID == id) {
+      const auto hash = ComputeFileHash(mPages[i].mPath);
+      if (!hash) {
+        return std::nullopt;
+      }
+      return nlohmann::json {{"PageIndex", i}, {"FileHash", hash}};
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<PageID> ImageFilePageSource::GetPageIDFromPersistentID(
+  const nlohmann::json& id) const {
+  if (!id.contains("PageIndex") || !id.contains("FileHash")) {
+    return std::nullopt;
+  }
+  const auto pageIndex = id.at("PageIndex").get<PageIndex>();
+  const auto storedHash = id.at("FileHash").get<uint64_t>();
+  if (pageIndex >= static_cast<PageIndex>(mPages.size())) {
+    return std::nullopt;
+  }
+  const auto currentHash = ComputeFileHash(mPages[pageIndex].mPath);
+  if (!currentHash || currentHash != storedHash) {
+    return std::nullopt;
+  }
+  return mPages[pageIndex].mID;
+}
+
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/PDFFilePageSource.cpp
+++ b/src/app/app-common/PageSource/PDFFilePageSource.cpp
@@ -652,7 +652,7 @@ fire_and_forget PDFFilePageSource::OnFileModified(
   }
 }
 
-std::optional<nlohmann::json> PDFFilePageSource::GetPersistentIDForPage(
+std::optional<std::string> PDFFilePageSource::GetPersistentIDForPage(
   PageID id) const {
   const auto pageIDs = this->GetPageIDs();
   const auto it = std::ranges::find(pageIDs, id);
@@ -661,24 +661,26 @@ std::optional<nlohmann::json> PDFFilePageSource::GetPersistentIDForPage(
   }
   const auto pageIndex
     = static_cast<PageIndex>(std::distance(pageIDs.begin(), it));
-  const auto hash = ComputeFileHash(this->GetPath());
+  const auto hash = PartialFileHash(this->GetPath());
   if (!hash) {
     return std::nullopt;
   }
-  return nlohmann::json {{"PageIndex", pageIndex}, {"FileHash", hash}};
+  return nlohmann::json {{"PageIndex", pageIndex}, {"FileHash", *hash}}.dump();
 }
 
 std::optional<PageID> PDFFilePageSource::GetPageIDFromPersistentID(
-  const nlohmann::json& id) const {
-  if (!id.contains("PageIndex") || !id.contains("FileHash")) {
+  std::string_view id) const {
+  const auto parsed = nlohmann::json::parse(id, nullptr, false);
+  if (parsed.is_discarded() || !parsed.contains("PageIndex")
+      || !parsed.contains("FileHash")) {
     return std::nullopt;
   }
-  const auto storedHash = id.at("FileHash").get<uint64_t>();
-  const auto currentHash = ComputeFileHash(this->GetPath());
-  if (!currentHash || currentHash != storedHash) {
+  const auto storedHash = parsed.at("FileHash").get<uint64_t>();
+  const auto currentHash = PartialFileHash(this->GetPath());
+  if (!currentHash || *currentHash != storedHash) {
     return std::nullopt;
   }
-  const auto pageIndex = id.at("PageIndex").get<PageIndex>();
+  const auto pageIndex = parsed.at("PageIndex").get<PageIndex>();
   const auto pageIDs = this->GetPageIDs();
   if (pageIndex >= static_cast<PageIndex>(pageIDs.size())) {
     return std::nullopt;

--- a/src/app/app-common/PageSource/PDFFilePageSource.cpp
+++ b/src/app/app-common/PageSource/PDFFilePageSource.cpp
@@ -9,6 +9,7 @@
 #include <OpenKneeboard/CursorEvent.hpp>
 #include <OpenKneeboard/DXResources.hpp>
 #include <OpenKneeboard/DoodleRenderer.hpp>
+#include <OpenKneeboard/FileHash.hpp>
 #include <OpenKneeboard/Filesystem.hpp>
 #include <OpenKneeboard/FilesystemWatcher.hpp>
 #include <OpenKneeboard/LaunchURI.hpp>
@@ -650,4 +651,39 @@ fire_and_forget PDFFilePageSource::OnFileModified(
     co_await this->Reload();
   }
 }
+
+std::optional<nlohmann::json> PDFFilePageSource::GetPersistentIDForPage(
+  PageID id) const {
+  const auto pageIDs = this->GetPageIDs();
+  const auto it = std::ranges::find(pageIDs, id);
+  if (it == pageIDs.end()) {
+    return std::nullopt;
+  }
+  const auto pageIndex
+    = static_cast<PageIndex>(std::distance(pageIDs.begin(), it));
+  const auto hash = ComputeFileHash(this->GetPath());
+  if (!hash) {
+    return std::nullopt;
+  }
+  return nlohmann::json {{"PageIndex", pageIndex}, {"FileHash", hash}};
+}
+
+std::optional<PageID> PDFFilePageSource::GetPageIDFromPersistentID(
+  const nlohmann::json& id) const {
+  if (!id.contains("PageIndex") || !id.contains("FileHash")) {
+    return std::nullopt;
+  }
+  const auto storedHash = id.at("FileHash").get<uint64_t>();
+  const auto currentHash = ComputeFileHash(this->GetPath());
+  if (!currentHash || currentHash != storedHash) {
+    return std::nullopt;
+  }
+  const auto pageIndex = id.at("PageIndex").get<PageIndex>();
+  const auto pageIDs = this->GetPageIDs();
+  if (pageIndex >= static_cast<PageIndex>(pageIDs.size())) {
+    return std::nullopt;
+  }
+  return pageIDs[pageIndex];
+}
+
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/PageSourceWithDelegates.cpp
+++ b/src/app/app-common/PageSource/PageSourceWithDelegates.cpp
@@ -333,4 +333,23 @@ fire_and_forget PageSourceWithDelegates::OpenDeveloperToolsWindow(
   co_return;
 }
 
+std::optional<nlohmann::json> PageSourceWithDelegates::GetPersistentIDForPage(
+  PageID id) const {
+  auto delegate = this->FindDelegate(id);
+  if (!delegate) {
+    return std::nullopt;
+  }
+  return delegate->GetPersistentIDForPage(id);
+}
+
+std::optional<PageID> PageSourceWithDelegates::GetPageIDFromPersistentID(
+  const nlohmann::json& id) const {
+  for (const auto& delegate: mDelegates) {
+    if (auto pageID = delegate->GetPageIDFromPersistentID(id)) {
+      return pageID;
+    }
+  }
+  return std::nullopt;
+}
+
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/PageSourceWithDelegates.cpp
+++ b/src/app/app-common/PageSource/PageSourceWithDelegates.cpp
@@ -333,7 +333,7 @@ fire_and_forget PageSourceWithDelegates::OpenDeveloperToolsWindow(
   co_return;
 }
 
-std::optional<nlohmann::json> PageSourceWithDelegates::GetPersistentIDForPage(
+std::optional<std::string> PageSourceWithDelegates::GetPersistentIDForPage(
   PageID id) const {
   auto delegate = this->FindDelegate(id);
   if (!delegate) {
@@ -343,7 +343,7 @@ std::optional<nlohmann::json> PageSourceWithDelegates::GetPersistentIDForPage(
 }
 
 std::optional<PageID> PageSourceWithDelegates::GetPageIDFromPersistentID(
-  const nlohmann::json& id) const {
+  std::string_view id) const {
   for (const auto& delegate: mDelegates) {
     if (auto pageID = delegate->GetPageIDFromPersistentID(id)) {
       return pageID;

--- a/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
+++ b/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
@@ -4,6 +4,7 @@
 //
 // This program is open source; see the LICENSE file in the root of the
 // OpenKneeboard repository.
+#include <OpenKneeboard/FileHash.hpp>
 #include <OpenKneeboard/PlainTextFilePageSource.hpp>
 #include <OpenKneeboard/PlainTextPageSource.hpp>
 
@@ -133,6 +134,46 @@ std::string PlainTextFilePageSource::GetFileContent() const {
 PageIndex PlainTextFilePageSource::GetPageCount() const {
   // Show placeholder "[empty file]" instead of 'no pages' error
   return std::max<PageIndex>(1, mPageSource->GetPageCount());
+}
+
+std::optional<nlohmann::json> PlainTextFilePageSource::GetPersistentIDForPage(
+  PageID id) const {
+  if (mPath.empty()) {
+    return std::nullopt;
+  }
+  const auto pageIDs = this->GetPageIDs();
+  const auto it = std::ranges::find(pageIDs, id);
+  if (it == pageIDs.end()) {
+    return std::nullopt;
+  }
+  const auto pageIndex
+    = static_cast<PageIndex>(std::distance(pageIDs.begin(), it));
+  const auto hash = ComputeFileHash(mPath);
+  if (!hash) {
+    return std::nullopt;
+  }
+  return nlohmann::json {{"PageIndex", pageIndex}, {"FileHash", hash}};
+}
+
+std::optional<PageID> PlainTextFilePageSource::GetPageIDFromPersistentID(
+  const nlohmann::json& id) const {
+  if (mPath.empty()) {
+    return std::nullopt;
+  }
+  if (!id.contains("PageIndex") || !id.contains("FileHash")) {
+    return std::nullopt;
+  }
+  const auto storedHash = id.at("FileHash").get<uint64_t>();
+  const auto currentHash = ComputeFileHash(mPath);
+  if (!currentHash || currentHash != storedHash) {
+    return std::nullopt;
+  }
+  const auto pageIndex = id.at("PageIndex").get<PageIndex>();
+  const auto pageIDs = this->GetPageIDs();
+  if (pageIndex >= static_cast<PageIndex>(pageIDs.size())) {
+    return std::nullopt;
+  }
+  return pageIDs[pageIndex];
 }
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
+++ b/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
@@ -136,7 +136,7 @@ PageIndex PlainTextFilePageSource::GetPageCount() const {
   return std::max<PageIndex>(1, mPageSource->GetPageCount());
 }
 
-std::optional<nlohmann::json> PlainTextFilePageSource::GetPersistentIDForPage(
+std::optional<std::string> PlainTextFilePageSource::GetPersistentIDForPage(
   PageID id) const {
   if (mPath.empty()) {
     return std::nullopt;
@@ -148,27 +148,29 @@ std::optional<nlohmann::json> PlainTextFilePageSource::GetPersistentIDForPage(
   }
   const auto pageIndex
     = static_cast<PageIndex>(std::distance(pageIDs.begin(), it));
-  const auto hash = ComputeFileHash(mPath);
+  const auto hash = PartialFileHash(mPath);
   if (!hash) {
     return std::nullopt;
   }
-  return nlohmann::json {{"PageIndex", pageIndex}, {"FileHash", hash}};
+  return nlohmann::json {{"PageIndex", pageIndex}, {"FileHash", *hash}}.dump();
 }
 
 std::optional<PageID> PlainTextFilePageSource::GetPageIDFromPersistentID(
-  const nlohmann::json& id) const {
+  std::string_view id) const {
   if (mPath.empty()) {
     return std::nullopt;
   }
-  if (!id.contains("PageIndex") || !id.contains("FileHash")) {
+  const auto parsed = nlohmann::json::parse(id, nullptr, false);
+  if (parsed.is_discarded() || !parsed.contains("PageIndex")
+      || !parsed.contains("FileHash")) {
     return std::nullopt;
   }
-  const auto storedHash = id.at("FileHash").get<uint64_t>();
-  const auto currentHash = ComputeFileHash(mPath);
-  if (!currentHash || currentHash != storedHash) {
+  const auto storedHash = parsed.at("FileHash").get<uint64_t>();
+  const auto currentHash = PartialFileHash(mPath);
+  if (!currentHash || *currentHash != storedHash) {
     return std::nullopt;
   }
-  const auto pageIndex = id.at("PageIndex").get<PageIndex>();
+  const auto pageIndex = parsed.at("PageIndex").get<PageIndex>();
   const auto pageIDs = this->GetPageIDs();
   if (pageIndex >= static_cast<PageIndex>(pageIDs.size())) {
     return std::nullopt;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/FileHash.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/FileHash.hpp
@@ -1,0 +1,55 @@
+// OpenKneeboard
+//
+// Copyright (c) 2025 Fred Emmott <fred@fredemmott.com>
+//
+// This program is open source; see the LICENSE file in the root of the
+// OpenKneeboard repository.
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+namespace OpenKneeboard {
+
+// FNV-1a 64-bit hash over the first 64 KiB of a file plus its total size.
+// Not a cryptographic hash; used only to detect replaced files so stale
+// bookmarks are not silently applied to changed content.
+inline uint64_t ComputeFileHash(const std::filesystem::path& path) noexcept {
+  try {
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(path, ec);
+    if (ec) {
+      return 0;
+    }
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+      return 0;
+    }
+    const auto readSize = static_cast<std::streamsize>(
+      std::min<std::uintmax_t>(size, 65536));
+    std::vector<char> buf(readSize);
+    file.read(buf.data(), readSize);
+    const auto n = static_cast<std::size_t>(file.gcount());
+
+    constexpr uint64_t kFNVOffsetBasis = 14695981039346656037ULL;
+    constexpr uint64_t kFNVPrime = 1099511628211ULL;
+    uint64_t hash = kFNVOffsetBasis;
+    for (std::size_t i = 0; i < n; ++i) {
+      hash ^= static_cast<uint8_t>(buf[i]);
+      hash *= kFNVPrime;
+    }
+    // Also mix in the file size to distinguish files with identical prefixes.
+    const auto* sizeBytes = reinterpret_cast<const uint8_t*>(&size);
+    for (std::size_t i = 0; i < sizeof(size); ++i) {
+      hash ^= sizeBytes[i];
+      hash *= kFNVPrime;
+    }
+    return hash ? hash : 1;
+  } catch (...) {
+    return 0;
+  }
+}
+
+}// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/include/OpenKneeboard/FileHash.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/FileHash.hpp
@@ -7,49 +7,16 @@
 #pragma once
 
 #include <cstdint>
+#include <expected>
 #include <filesystem>
-#include <fstream>
-#include <vector>
+#include <system_error>
 
 namespace OpenKneeboard {
 
 // FNV-1a 64-bit hash over the first 64 KiB of a file plus its total size.
 // Not a cryptographic hash; used only to detect replaced files so stale
 // bookmarks are not silently applied to changed content.
-inline uint64_t ComputeFileHash(const std::filesystem::path& path) noexcept {
-  try {
-    std::error_code ec;
-    const auto size = std::filesystem::file_size(path, ec);
-    if (ec) {
-      return 0;
-    }
-    std::ifstream file(path, std::ios::binary);
-    if (!file) {
-      return 0;
-    }
-    const auto readSize = static_cast<std::streamsize>(
-      std::min<std::uintmax_t>(size, 65536));
-    std::vector<char> buf(readSize);
-    file.read(buf.data(), readSize);
-    const auto n = static_cast<std::size_t>(file.gcount());
-
-    constexpr uint64_t kFNVOffsetBasis = 14695981039346656037ULL;
-    constexpr uint64_t kFNVPrime = 1099511628211ULL;
-    uint64_t hash = kFNVOffsetBasis;
-    for (std::size_t i = 0; i < n; ++i) {
-      hash ^= static_cast<uint8_t>(buf[i]);
-      hash *= kFNVPrime;
-    }
-    // Also mix in the file size to distinguish files with identical prefixes.
-    const auto* sizeBytes = reinterpret_cast<const uint8_t*>(&size);
-    for (std::size_t i = 0; i < sizeof(size); ++i) {
-      hash ^= sizeBytes[i];
-      hash *= kFNVPrime;
-    }
-    return hash ? hash : 1;
-  } catch (...) {
-    return 0;
-  }
-}
+std::expected<uint64_t, std::error_code> PartialFileHash(
+  const std::filesystem::path& path) noexcept;
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/PageSource/include/OpenKneeboard/FolderPageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/FolderPageSource.hpp
@@ -16,8 +16,6 @@
 
 #include <filesystem>
 #include <memory>
-#include <optional>
-#include <utility>
 
 namespace OpenKneeboard {
 
@@ -39,25 +37,6 @@ class FolderPageSource final : public PageSourceWithDelegates {
 
   [[nodiscard]]
   task<void> Reload() noexcept;
-
-  // Returns the path relative to GetPath() and the local page index within
-  // that file for a given global PageID; returns nullopt if not found.
-  [[nodiscard]]
-  std::optional<std::pair<std::filesystem::path, PageIndex>>
-  GetFileAndLocalIndexForPageID(PageID id) const;
-
-  // Returns the global PageID for a file given by a path relative to
-  // GetPath() and a local page index within that file; returns nullopt if
-  // the file is not loaded or localIndex is out of range.
-  [[nodiscard]]
-  std::optional<PageID> GetPageIDForRelativeFile(
-    const std::filesystem::path& relativeFile,
-    PageIndex localIndex) const;
-
-  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
-    PageID) const override;
-  virtual std::optional<PageID> GetPageIDFromPersistentID(
-    const nlohmann::json&) const override;
 
  private:
   void SubscribeToChanges();

--- a/src/app/app-common/PageSource/include/OpenKneeboard/FolderPageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/FolderPageSource.hpp
@@ -16,6 +16,8 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
+#include <utility>
 
 namespace OpenKneeboard {
 
@@ -37,6 +39,20 @@ class FolderPageSource final : public PageSourceWithDelegates {
 
   [[nodiscard]]
   task<void> Reload() noexcept;
+
+  // Returns the path relative to GetPath() and the local page index within
+  // that file for a given global PageID; returns nullopt if not found.
+  [[nodiscard]]
+  std::optional<std::pair<std::filesystem::path, PageIndex>>
+  GetFileAndLocalIndexForPageID(PageID id) const;
+
+  // Returns the global PageID for a file given by a path relative to
+  // GetPath() and a local page index within that file; returns nullopt if
+  // the file is not loaded or localIndex is out of range.
+  [[nodiscard]]
+  std::optional<PageID> GetPageIDForRelativeFile(
+    const std::filesystem::path& relativeFile,
+    PageIndex localIndex) const;
 
  private:
   void SubscribeToChanges();

--- a/src/app/app-common/PageSource/include/OpenKneeboard/FolderPageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/FolderPageSource.hpp
@@ -54,6 +54,11 @@ class FolderPageSource final : public PageSourceWithDelegates {
     const std::filesystem::path& relativeFile,
     PageIndex localIndex) const;
 
+  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+    PageID) const override;
+  virtual std::optional<PageID> GetPageIDFromPersistentID(
+    const nlohmann::json&) const override;
+
  private:
   void SubscribeToChanges();
   OpenKneeboard::fire_and_forget OnFileModified(std::filesystem::path);

--- a/src/app/app-common/PageSource/include/OpenKneeboard/IPageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/IPageSource.hpp
@@ -16,10 +16,10 @@
 
 #include <OpenKneeboard/inttypes.hpp>
 
-#include <shims/nlohmann/json.hpp>
-
 #include <cstdint>
 #include <optional>
+#include <string>
+#include <string_view>
 
 #include <d2d1_1.h>
 
@@ -44,16 +44,18 @@ class IPageSource {
   virtual task<void> RenderPage(RenderContext, PageID, PixelRect rect) = 0;
 
   // Returns a stable, serializable identifier for a page that can survive
-  // application restarts. The identifier includes any data needed to validate
-  // that the underlying content has not changed (e.g. a file hash).
-  // Returns nullopt if this page source does not support persistent bookmarks.
-  virtual std::optional<nlohmann::json> GetPersistentIDForPage(PageID) const;
+  // application restarts. The identifier is an opaque string (the concrete
+  // page source chooses its own encoding, typically serialized JSON) and
+  // includes any data needed to validate that the underlying content has not
+  // changed (e.g. a file hash). Returns nullopt if this page source does not
+  // support persistent bookmarks.
+  virtual std::optional<std::string> GetPersistentIDForPage(PageID) const;
 
   // Resolves a previously returned persistent ID back to a live PageID.
   // Returns nullopt if the page is not found or if the underlying content has
   // changed since the identifier was created.
   virtual std::optional<PageID> GetPageIDFromPersistentID(
-    const nlohmann::json&) const;
+    std::string_view) const;
 
   Event<> evNeedsRepaintEvent;
   Event<SuggestedPageAppendAction> evPageAppendedEvent;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/IPageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/IPageSource.hpp
@@ -16,7 +16,10 @@
 
 #include <OpenKneeboard/inttypes.hpp>
 
+#include <shims/nlohmann/json.hpp>
+
 #include <cstdint>
+#include <optional>
 
 #include <d2d1_1.h>
 
@@ -39,6 +42,18 @@ class IPageSource {
 
   virtual std::optional<PreferredSize> GetPreferredSize(PageID) = 0;
   virtual task<void> RenderPage(RenderContext, PageID, PixelRect rect) = 0;
+
+  // Returns a stable, serializable identifier for a page that can survive
+  // application restarts. The identifier includes any data needed to validate
+  // that the underlying content has not changed (e.g. a file hash).
+  // Returns nullopt if this page source does not support persistent bookmarks.
+  virtual std::optional<nlohmann::json> GetPersistentIDForPage(PageID) const;
+
+  // Resolves a previously returned persistent ID back to a live PageID.
+  // Returns nullopt if the page is not found or if the underlying content has
+  // changed since the identifier was created.
+  virtual std::optional<PageID> GetPageIDFromPersistentID(
+    const nlohmann::json&) const;
 
   Event<> evNeedsRepaintEvent;
   Event<SuggestedPageAppendAction> evPageAppendedEvent;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/ImageFilePageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/ImageFilePageSource.hpp
@@ -45,6 +45,11 @@ class ImageFilePageSource final
 
   task<void> RenderPage(RenderContext, PageID, PixelRect rect) final override;
 
+  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+    PageID) const override;
+  virtual std::optional<PageID> GetPageIDFromPersistentID(
+    const nlohmann::json&) const override;
+
   virtual bool IsNavigationAvailable() const override;
   virtual std::vector<NavigationEntry> GetNavigationEntries() const override;
 

--- a/src/app/app-common/PageSource/include/OpenKneeboard/ImageFilePageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/ImageFilePageSource.hpp
@@ -45,10 +45,10 @@ class ImageFilePageSource final
 
   task<void> RenderPage(RenderContext, PageID, PixelRect rect) final override;
 
-  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+  virtual std::optional<std::string> GetPersistentIDForPage(
     PageID) const override;
   virtual std::optional<PageID> GetPageIDFromPersistentID(
-    const nlohmann::json&) const override;
+    std::string_view) const override;
 
   virtual bool IsNavigationAvailable() const override;
   virtual std::vector<NavigationEntry> GetNavigationEntries() const override;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PDFFilePageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PDFFilePageSource.hpp
@@ -66,10 +66,10 @@ class PDFFilePageSource final
 
   task<void> RenderPage(RenderContext, PageID, PixelRect rect) override;
 
-  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+  virtual std::optional<std::string> GetPersistentIDForPage(
     PageID) const override;
   virtual std::optional<PageID> GetPageIDFromPersistentID(
-    const nlohmann::json&) const override;
+    std::string_view) const override;
 
  private:
   winrt::apartment_context mUIThread;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PDFFilePageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PDFFilePageSource.hpp
@@ -66,6 +66,11 @@ class PDFFilePageSource final
 
   task<void> RenderPage(RenderContext, PageID, PixelRect rect) override;
 
+  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+    PageID) const override;
+  virtual std::optional<PageID> GetPageIDFromPersistentID(
+    const nlohmann::json&) const override;
+
  private:
   winrt::apartment_context mUIThread;
   // Useful because `wil::resume_foreground()` will *always* enqueue, never

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PageSourceWithDelegates.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PageSourceWithDelegates.hpp
@@ -65,6 +65,11 @@ class PageSourceWithDelegates
   bool HasDeveloperTools(PageID) const override;
   fire_and_forget OpenDeveloperToolsWindow(KneeboardViewID, PageID) override;
 
+  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+    PageID) const override;
+  virtual std::optional<PageID> GetPageIDFromPersistentID(
+    const nlohmann::json&) const override;
+
  protected:
   DisposalState mDisposal;
 

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PageSourceWithDelegates.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PageSourceWithDelegates.hpp
@@ -65,10 +65,10 @@ class PageSourceWithDelegates
   bool HasDeveloperTools(PageID) const override;
   fire_and_forget OpenDeveloperToolsWindow(KneeboardViewID, PageID) override;
 
-  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+  virtual std::optional<std::string> GetPersistentIDForPage(
     PageID) const override;
   virtual std::optional<PageID> GetPageIDFromPersistentID(
-    const nlohmann::json&) const override;
+    std::string_view) const override;
 
  protected:
   DisposalState mDisposal;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextFilePageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextFilePageSource.hpp
@@ -39,6 +39,11 @@ class PlainTextFilePageSource final : public PageSourceWithDelegates {
 
   PageIndex GetPageCount() const override;
 
+  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+    PageID) const override;
+  virtual std::optional<PageID> GetPageIDFromPersistentID(
+    const nlohmann::json&) const override;
+
   void Reload();
 
  private:

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextFilePageSource.hpp
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextFilePageSource.hpp
@@ -39,10 +39,10 @@ class PlainTextFilePageSource final : public PageSourceWithDelegates {
 
   PageIndex GetPageCount() const override;
 
-  virtual std::optional<nlohmann::json> GetPersistentIDForPage(
+  virtual std::optional<std::string> GetPersistentIDForPage(
     PageID) const override;
   virtual std::optional<PageID> GetPageIDFromPersistentID(
-    const nlohmann::json&) const override;
+    std::string_view) const override;
 
   void Reload();
 

--- a/src/app/app-common/Tab/FolderTab.cpp
+++ b/src/app/app-common/Tab/FolderTab.cpp
@@ -22,9 +22,6 @@ FolderTab::FolderTab(
     PageSourceWithDelegates(dxr, kbs),
     mDXResources(dxr),
     mKneeboard(kbs) {
-  AddEventListener(
-    this->evContentChangedEvent,
-    std::bind_front(&FolderTab::OnFolderContentChanged, this));
 }
 
 task<std::shared_ptr<FolderTab>> FolderTab::Create(
@@ -52,51 +49,6 @@ FolderTab::~FolderTab() {}
 
 const FolderPageSource* FolderTab::GetPageSource() const {
   return mPageSource.get();
-}
-
-void FolderTab::OnFolderContentChanged() {
-  if (mPendingFolderBookmarks.empty() || !mPageSource) {
-    return;
-  }
-  const auto pageIDs = this->GetPageIDs();
-  if (pageIDs.empty()) {
-    return;
-  }
-  std::vector<Bookmark> restored;
-  for (const auto& pending: mPendingFolderBookmarks) {
-    if (const auto pageID = mPageSource->GetPageIDForRelativeFile(
-          pending.mRelFile, pending.mLocalPageIndex)) {
-      restored.push_back({GetRuntimeID(), *pageID, pending.mTitle});
-    }
-  }
-  mPendingFolderBookmarks.clear();
-  if (!restored.empty()) {
-    this->SetBookmarks(restored);
-  }
-}
-
-void FolderTab::SetFolderPendingBookmarkRestore(
-  std::vector<FolderPendingBookmark> pending) {
-  if (!mPageSource || this->GetPageIDs().empty()) {
-    mPendingFolderBookmarks = std::move(pending);
-    return;
-  }
-  // Content already loaded: resolve immediately.
-  std::vector<Bookmark> restored;
-  for (const auto& entry: pending) {
-    if (const auto pageID = mPageSource->GetPageIDForRelativeFile(
-          entry.mRelFile, entry.mLocalPageIndex)) {
-      restored.push_back({GetRuntimeID(), *pageID, entry.mTitle});
-    }
-  }
-  if (!restored.empty()) {
-    this->SetBookmarks(restored);
-  }
-}
-
-std::vector<FolderTab::FolderPendingBookmark>
-FolderTab::GetFolderPendingBookmarkData() const {
-  return mPendingFolderBookmarks;
 }
 
 nlohmann::json FolderTab::GetSettings() const { return {{"Path", GetPath()}}; }

--- a/src/app/app-common/Tab/FolderTab.cpp
+++ b/src/app/app-common/Tab/FolderTab.cpp
@@ -21,7 +21,11 @@ FolderTab::FolderTab(
   : TabBase(persistentID, title),
     PageSourceWithDelegates(dxr, kbs),
     mDXResources(dxr),
-    mKneeboard(kbs) {}
+    mKneeboard(kbs) {
+  AddEventListener(
+    this->evContentChangedEvent,
+    std::bind_front(&FolderTab::OnFolderContentChanged, this));
+}
 
 task<std::shared_ptr<FolderTab>> FolderTab::Create(
   const audited_ptr<DXResources>& dxr,
@@ -45,6 +49,55 @@ task<std::shared_ptr<FolderTab>> FolderTab::Create(
 }
 
 FolderTab::~FolderTab() {}
+
+const FolderPageSource* FolderTab::GetPageSource() const {
+  return mPageSource.get();
+}
+
+void FolderTab::OnFolderContentChanged() {
+  if (mPendingFolderBookmarks.empty() || !mPageSource) {
+    return;
+  }
+  const auto pageIDs = this->GetPageIDs();
+  if (pageIDs.empty()) {
+    return;
+  }
+  std::vector<Bookmark> restored;
+  for (const auto& pending: mPendingFolderBookmarks) {
+    if (const auto pageID = mPageSource->GetPageIDForRelativeFile(
+          pending.mRelFile, pending.mLocalPageIndex)) {
+      restored.push_back({GetRuntimeID(), *pageID, pending.mTitle});
+    }
+  }
+  mPendingFolderBookmarks.clear();
+  if (!restored.empty()) {
+    this->SetBookmarks(restored);
+  }
+}
+
+void FolderTab::SetFolderPendingBookmarkRestore(
+  std::vector<FolderPendingBookmark> pending) {
+  if (!mPageSource || this->GetPageIDs().empty()) {
+    mPendingFolderBookmarks = std::move(pending);
+    return;
+  }
+  // Content already loaded: resolve immediately.
+  std::vector<Bookmark> restored;
+  for (const auto& entry: pending) {
+    if (const auto pageID = mPageSource->GetPageIDForRelativeFile(
+          entry.mRelFile, entry.mLocalPageIndex)) {
+      restored.push_back({GetRuntimeID(), *pageID, entry.mTitle});
+    }
+  }
+  if (!restored.empty()) {
+    this->SetBookmarks(restored);
+  }
+}
+
+std::vector<FolderTab::FolderPendingBookmark>
+FolderTab::GetFolderPendingBookmarkData() const {
+  return mPendingFolderBookmarks;
+}
 
 nlohmann::json FolderTab::GetSettings() const { return {{"Path", GetPath()}}; }
 

--- a/src/app/app-common/Tab/TabBase.cpp
+++ b/src/app/app-common/Tab/TabBase.cpp
@@ -82,7 +82,7 @@ void TabBase::SetPendingBookmarkRestore(std::vector<PendingBookmark> pending) {
   mPendingBookmarks = std::move(pending);
 }
 
-std::vector<TabBase::PendingBookmark> TabBase::GetPendingBookmarkData() const {
+std::vector<ITab::PendingBookmark> TabBase::GetPendingBookmarkData() const {
   return mPendingBookmarks.value_or(std::vector<PendingBookmark> {});
 }
 

--- a/src/app/app-common/Tab/TabBase.cpp
+++ b/src/app/app-common/Tab/TabBase.cpp
@@ -64,15 +64,14 @@ void TabBase::SetBookmarks(const std::vector<Bookmark>& bookmarks) {
   evSettingsChangedEvent.Emit();
 }
 
-void TabBase::SetPendingBookmarkRestore(PendingBookmarkData pending) {
-  const auto pageIDs = this->GetPageIDs();
-  if (!pageIDs.empty()) {
+void TabBase::SetPendingBookmarkRestore(std::vector<PendingBookmark> pending) {
+  if (!this->GetPageIDs().empty()) {
     // Content already loaded (e.g. folder scan completed before we were called):
     // apply immediately instead of waiting for evContentChangedEvent.
     std::vector<Bookmark> restored;
-    for (const auto& [pageIndex, title]: pending.mPages) {
-      if (pageIndex < pageIDs.size()) {
-        restored.push_back({mRuntimeID, pageIDs[pageIndex], title});
+    for (const auto& bm: pending) {
+      if (auto pageID = this->GetPageIDFromPersistentID(bm.mPersistentID)) {
+        restored.push_back({mRuntimeID, *pageID, bm.mTitle});
       }
     }
     // Event listeners are not set up yet at this point, so emitting events
@@ -83,9 +82,8 @@ void TabBase::SetPendingBookmarkRestore(PendingBookmarkData pending) {
   mPendingBookmarks = std::move(pending);
 }
 
-std::optional<TabBase::PendingBookmarkData>
-TabBase::GetPendingBookmarkData() const {
-  return mPendingBookmarks;
+std::vector<TabBase::PendingBookmark> TabBase::GetPendingBookmarkData() const {
+  return mPendingBookmarks.value_or(std::vector<PendingBookmark> {});
 }
 
 void TabBase::OnContentChanged() {
@@ -94,9 +92,9 @@ void TabBase::OnContentChanged() {
   if (mPendingBookmarks.has_value()) {
     if (!pageIDs.empty()) {
       std::vector<Bookmark> restored;
-      for (const auto& [pageIndex, title]: mPendingBookmarks->mPages) {
-        if (pageIndex < pageIDs.size()) {
-          restored.push_back({mRuntimeID, pageIDs[pageIndex], title});
+      for (const auto& bm: *mPendingBookmarks) {
+        if (auto pageID = this->GetPageIDFromPersistentID(bm.mPersistentID)) {
+          restored.push_back({mRuntimeID, *pageID, bm.mTitle});
         }
       }
       mPendingBookmarks.reset();

--- a/src/app/app-common/Tab/TabBase.cpp
+++ b/src/app/app-common/Tab/TabBase.cpp
@@ -61,11 +61,51 @@ void TabBase::SetBookmarks(const std::vector<Bookmark>& bookmarks) {
   mBookmarks = bookmarks;
   evAvailableFeaturesChangedEvent.Emit();
   evBookmarksChangedEvent.Emit();
+  evSettingsChangedEvent.Emit();
+}
+
+void TabBase::SetPendingBookmarkRestore(PendingBookmarkData pending) {
+  const auto pageIDs = this->GetPageIDs();
+  if (!pageIDs.empty()) {
+    // Content already loaded (e.g. folder scan completed before we were called):
+    // apply immediately instead of waiting for evContentChangedEvent.
+    std::vector<Bookmark> restored;
+    for (const auto& [pageIndex, title]: pending.mPages) {
+      if (pageIndex < pageIDs.size()) {
+        restored.push_back({mRuntimeID, pageIDs[pageIndex], title});
+      }
+    }
+    // Event listeners are not set up yet at this point, so emitting events
+    // here is safe and harmless.
+    this->SetBookmarks(restored);
+    return;
+  }
+  mPendingBookmarks = std::move(pending);
+}
+
+std::optional<TabBase::PendingBookmarkData>
+TabBase::GetPendingBookmarkData() const {
+  return mPendingBookmarks;
 }
 
 void TabBase::OnContentChanged() {
-  decltype(mBookmarks) bookmarks;
   const auto pageIDs = this->GetPageIDs();
+
+  if (mPendingBookmarks.has_value()) {
+    if (!pageIDs.empty()) {
+      std::vector<Bookmark> restored;
+      for (const auto& [pageIndex, title]: mPendingBookmarks->mPages) {
+        if (pageIndex < pageIDs.size()) {
+          restored.push_back({mRuntimeID, pageIDs[pageIndex], title});
+        }
+      }
+      mPendingBookmarks.reset();
+      this->SetBookmarks(restored);
+    }
+    return;
+  }
+
+  decltype(mBookmarks) bookmarks;
   for (const auto& bookmark: mBookmarks) {
     if (std::ranges::find(pageIDs, bookmark.mPageID) != pageIDs.end()) {
       bookmarks.push_back(bookmark);

--- a/src/app/app-common/Tab/include/OpenKneeboard/FolderTab.hpp
+++ b/src/app/app-common/Tab/include/OpenKneeboard/FolderTab.hpp
@@ -12,6 +12,7 @@
 
 #include <OpenKneeboard/audited_ptr.hpp>
 
+#include <cstdint>
 #include <filesystem>
 
 namespace OpenKneeboard {
@@ -45,6 +46,22 @@ class FolderTab final : public TabBase,
   [[nodiscard]]
   virtual task<void> SetPath(std::filesystem::path);
 
+  // Returns the active FolderPageSource, or nullptr if not yet initialised.
+  const FolderPageSource* GetPageSource() const;
+
+  // Bookmark entry for folder tabs: keyed by relative file path and local
+  // page index so bookmarks survive other files being added/removed.
+  struct FolderPendingBookmark {
+    std::filesystem::path mRelFile;
+    uint64_t mFileHash {0};
+    PageIndex mLocalPageIndex {0};
+    std::string mTitle;
+  };
+
+  void SetFolderPendingBookmarkRestore(
+    std::vector<FolderPendingBookmark> pending);
+  std::vector<FolderPendingBookmark> GetFolderPendingBookmarkData() const;
+
  private:
   FolderTab(
     const audited_ptr<DXResources>&,
@@ -57,6 +74,9 @@ class FolderTab final : public TabBase,
 
   std::shared_ptr<FolderPageSource> mPageSource;
   std::filesystem::path mPath;
+
+  std::vector<FolderPendingBookmark> mPendingFolderBookmarks;
+  void OnFolderContentChanged();
 };
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/Tab/include/OpenKneeboard/FolderTab.hpp
+++ b/src/app/app-common/Tab/include/OpenKneeboard/FolderTab.hpp
@@ -49,19 +49,6 @@ class FolderTab final : public TabBase,
   // Returns the active FolderPageSource, or nullptr if not yet initialised.
   const FolderPageSource* GetPageSource() const;
 
-  // Bookmark entry for folder tabs: keyed by relative file path and local
-  // page index so bookmarks survive other files being added/removed.
-  struct FolderPendingBookmark {
-    std::filesystem::path mRelFile;
-    uint64_t mFileHash {0};
-    PageIndex mLocalPageIndex {0};
-    std::string mTitle;
-  };
-
-  void SetFolderPendingBookmarkRestore(
-    std::vector<FolderPendingBookmark> pending);
-  std::vector<FolderPendingBookmark> GetFolderPendingBookmarkData() const;
-
  private:
   FolderTab(
     const audited_ptr<DXResources>&,
@@ -74,9 +61,6 @@ class FolderTab final : public TabBase,
 
   std::shared_ptr<FolderPageSource> mPageSource;
   std::filesystem::path mPath;
-
-  std::vector<FolderPendingBookmark> mPendingFolderBookmarks;
-  void OnFolderContentChanged();
 };
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/Tab/include/OpenKneeboard/ITab.hpp
+++ b/src/app/app-common/Tab/include/OpenKneeboard/ITab.hpp
@@ -42,6 +42,24 @@ class ITab : public virtual IPageSource {
   virtual std::vector<Bookmark> GetBookmarks() const = 0;
   virtual void SetBookmarks(const std::vector<Bookmark>&) = 0;
 
+  // A bookmark to be restored once the page source has finished loading.
+  // The persistent ID is opaque data returned by
+  // IPageSource::GetPersistentIDForPage().
+  struct PendingBookmark {
+    std::string mPersistentID;
+    std::string mTitle;
+  };
+
+  virtual void SetPendingBookmarkRestore(std::vector<PendingBookmark>) {
+  }
+
+  // Returns pending bookmarks for pass-through serialization during startup,
+  // before content is loaded and pending bookmarks have been applied.
+  [[nodiscard]]
+  virtual std::vector<PendingBookmark> GetPendingBookmarkData() const {
+    return {};
+  }
+
   Event<> evSettingsChangedEvent;
   Event<> evBookmarksChangedEvent;
 };

--- a/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
+++ b/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
@@ -10,8 +10,11 @@
 
 #include <OpenKneeboard/Bookmark.hpp>
 
-#include <cstdint>
+#include <shims/nlohmann/json.hpp>
+
 #include <optional>
+#include <string>
+#include <vector>
 
 namespace OpenKneeboard {
 
@@ -28,19 +31,18 @@ class TabBase : public virtual ITab, public virtual EventReceiver {
   virtual std::vector<Bookmark> GetBookmarks() const override final;
   virtual void SetBookmarks(const std::vector<Bookmark>&) override final;
 
-  // Pending bookmark data for file-based tabs (SingleFileTab).
-  // mFileHash is carried so that a startup save does not lose the hash
-  // before content finishes loading.
-  struct PendingBookmarkData {
-    uint64_t mFileHash {0};
-    std::vector<std::pair<PageIndex, std::string>> mPages;
+  // A bookmark to be restored once the page source has finished loading.
+  // The persistent ID is opaque data returned by IPageSource::GetPersistentIDForPage().
+  struct PendingBookmark {
+    nlohmann::json mPersistentID;
+    std::string mTitle;
   };
 
-  void SetPendingBookmarkRestore(PendingBookmarkData pending);
+  void SetPendingBookmarkRestore(std::vector<PendingBookmark> pending);
 
-  // Returns pending bookmark data for pass-through serialization during
-  // startup, before content is loaded and pending bookmarks have been applied.
-  std::optional<PendingBookmarkData> GetPendingBookmarkData() const;
+  // Returns pending bookmarks for pass-through serialization during startup,
+  // before content is loaded and pending bookmarks have been applied.
+  std::vector<PendingBookmark> GetPendingBookmarkData() const;
 
  protected:
   TabBase(const winrt::guid& persistentID, std::string_view title);
@@ -50,7 +52,7 @@ class TabBase : public virtual ITab, public virtual EventReceiver {
   const RuntimeID mRuntimeID;
   std::string mTitle;
   std::vector<Bookmark> mBookmarks;
-  std::optional<PendingBookmarkData> mPendingBookmarks;
+  std::optional<std::vector<PendingBookmark>> mPendingBookmarks;
 
   void OnContentChanged();
 };

--- a/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
+++ b/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
@@ -10,6 +10,9 @@
 
 #include <OpenKneeboard/Bookmark.hpp>
 
+#include <cstdint>
+#include <optional>
+
 namespace OpenKneeboard {
 
 class TabBase : public virtual ITab, public virtual EventReceiver {
@@ -25,6 +28,20 @@ class TabBase : public virtual ITab, public virtual EventReceiver {
   virtual std::vector<Bookmark> GetBookmarks() const override final;
   virtual void SetBookmarks(const std::vector<Bookmark>&) override final;
 
+  // Pending bookmark data for file-based tabs (SingleFileTab).
+  // mFileHash is carried so that a startup save does not lose the hash
+  // before content finishes loading.
+  struct PendingBookmarkData {
+    uint64_t mFileHash {0};
+    std::vector<std::pair<PageIndex, std::string>> mPages;
+  };
+
+  void SetPendingBookmarkRestore(PendingBookmarkData pending);
+
+  // Returns pending bookmark data for pass-through serialization during
+  // startup, before content is loaded and pending bookmarks have been applied.
+  std::optional<PendingBookmarkData> GetPendingBookmarkData() const;
+
  protected:
   TabBase(const winrt::guid& persistentID, std::string_view title);
 
@@ -33,6 +50,7 @@ class TabBase : public virtual ITab, public virtual EventReceiver {
   const RuntimeID mRuntimeID;
   std::string mTitle;
   std::vector<Bookmark> mBookmarks;
+  std::optional<PendingBookmarkData> mPendingBookmarks;
 
   void OnContentChanged();
 };

--- a/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
+++ b/src/app/app-common/Tab/include/OpenKneeboard/TabBase.hpp
@@ -10,8 +10,6 @@
 
 #include <OpenKneeboard/Bookmark.hpp>
 
-#include <shims/nlohmann/json.hpp>
-
 #include <optional>
 #include <string>
 #include <vector>
@@ -31,18 +29,9 @@ class TabBase : public virtual ITab, public virtual EventReceiver {
   virtual std::vector<Bookmark> GetBookmarks() const override final;
   virtual void SetBookmarks(const std::vector<Bookmark>&) override final;
 
-  // A bookmark to be restored once the page source has finished loading.
-  // The persistent ID is opaque data returned by IPageSource::GetPersistentIDForPage().
-  struct PendingBookmark {
-    nlohmann::json mPersistentID;
-    std::string mTitle;
-  };
-
-  void SetPendingBookmarkRestore(std::vector<PendingBookmark> pending);
-
-  // Returns pending bookmarks for pass-through serialization during startup,
-  // before content is loaded and pending bookmarks have been applied.
-  std::vector<PendingBookmark> GetPendingBookmarkData() const;
+  virtual void SetPendingBookmarkRestore(
+    std::vector<PendingBookmark> pending) override;
+  virtual std::vector<PendingBookmark> GetPendingBookmarkData() const override;
 
  protected:
   TabBase(const winrt::guid& persistentID, std::string_view title);

--- a/src/app/app-common/TabsList/TabsList.cpp
+++ b/src/app/app-common/TabsList/TabsList.cpp
@@ -55,6 +55,63 @@ static std::tuple<std::string, nlohmann::json> MigrateTab(
   return {type, settings};
 }
 
+static void ApplyPendingBookmarks(
+  ITab& tab,
+  const nlohmann::json& bmArray) {
+  if (!bmArray.is_array()) {
+    return;
+  }
+  std::vector<ITab::PendingBookmark> pending;
+  for (const auto& entry: bmArray) {
+    if (!entry.contains("PersistentID") || !entry.contains("Title")) {
+      continue;
+    }
+    pending.push_back({
+      entry.at("PersistentID").dump(),
+      entry.at("Title").get<std::string>(),
+    });
+  }
+  if (!pending.empty()) {
+    tab.SetPendingBookmarkRestore(std::move(pending));
+  }
+}
+
+static nlohmann::json SerializeTabBookmarks(const ITab& tab) {
+  nlohmann::json bmArray = nlohmann::json::array();
+
+  const auto liveBookmarks = tab.GetBookmarks();
+  if (!liveBookmarks.empty()) {
+    for (const auto& bm: liveBookmarks) {
+      auto persistentID = tab.GetPersistentIDForPage(bm.mPageID);
+      if (!persistentID) {
+        continue;
+      }
+      auto parsed = nlohmann::json::parse(*persistentID, nullptr, false);
+      if (parsed.is_discarded()) {
+        continue;
+      }
+      bmArray.push_back({
+        {"PersistentID", std::move(parsed)},
+        {"Title", bm.mTitle},
+      });
+    }
+    return bmArray;
+  }
+
+  // Pass-through during startup before content is loaded.
+  for (const auto& pending: tab.GetPendingBookmarkData()) {
+    auto parsed = nlohmann::json::parse(pending.mPersistentID, nullptr, false);
+    if (parsed.is_discarded()) {
+      continue;
+    }
+    bmArray.push_back({
+      {"PersistentID", std::move(parsed)},
+      {"Title", pending.mTitle},
+    });
+  }
+  return bmArray;
+}
+
 
 task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
   const nlohmann::json tab) {
@@ -115,24 +172,7 @@ task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
   }
 
   if (tab.contains("Bookmarks")) {
-    if (const auto tabBase = std::dynamic_pointer_cast<TabBase>(result)) {
-      const auto& bmArray = tab.at("Bookmarks");
-      if (bmArray.is_array()) {
-        std::vector<TabBase::PendingBookmark> pending;
-        for (const auto& entry: bmArray) {
-          if (!entry.contains("PersistentID") || !entry.contains("Title")) {
-            continue;
-          }
-          pending.push_back({
-            entry.at("PersistentID"),
-            entry.at("Title").get<std::string>(),
-          });
-        }
-        if (!pending.empty()) {
-          tabBase->SetPendingBookmarkRestore(std::move(pending));
-        }
-      }
-    }
+    ApplyPendingBookmarks(*result, tab.at("Bookmarks"));
   }
 
   co_return result;
@@ -219,30 +259,9 @@ nlohmann::json TabsList::GetSettings() const {
       }
     }
 
-    if (const auto tabBase = std::dynamic_pointer_cast<TabBase>(tab)) {
-      nlohmann::json bmArray = nlohmann::json::array();
-      const auto liveBookmarks = tabBase->GetBookmarks();
-      if (!liveBookmarks.empty()) {
-        for (const auto& bm: liveBookmarks) {
-          if (auto persistentID = tabBase->GetPersistentIDForPage(bm.mPageID)) {
-            bmArray.push_back({
-              {"PersistentID", std::move(*persistentID)},
-              {"Title", bm.mTitle},
-            });
-          }
-        }
-      } else {
-        // Pass-through during startup before content is loaded.
-        for (const auto& pending: tabBase->GetPendingBookmarkData()) {
-          bmArray.push_back({
-            {"PersistentID", pending.mPersistentID},
-            {"Title", pending.mTitle},
-          });
-        }
-      }
-      if (!bmArray.empty()) {
-        savedTab.emplace("Bookmarks", std::move(bmArray));
-      }
+    auto bmArray = SerializeTabBookmarks(*tab);
+    if (!bmArray.empty()) {
+      savedTab.emplace("Bookmarks", std::move(bmArray));
     }
 
     ret.push_back(savedTab);

--- a/src/app/app-common/TabsList/TabsList.cpp
+++ b/src/app/app-common/TabsList/TabsList.cpp
@@ -9,10 +9,10 @@
 #include <OpenKneeboard/DCSRadioLogTab.hpp>
 #include <OpenKneeboard/DCSTerrainTab.hpp>
 #include <OpenKneeboard/Filesystem.hpp>
-#include <OpenKneeboard/FolderPageSource.hpp>
 #include <OpenKneeboard/KneeboardState.hpp>
 #include <OpenKneeboard/PluginTab.hpp>
 #include <OpenKneeboard/RuntimeFiles.hpp>
+#include <OpenKneeboard/TabBase.hpp>
 #include <OpenKneeboard/TabTypes.hpp>
 #include <OpenKneeboard/TabView.hpp>
 #include <OpenKneeboard/TabsList.hpp>
@@ -55,30 +55,6 @@ static std::tuple<std::string, nlohmann::json> MigrateTab(
   return {type, settings};
 }
 
-// Polynomial hash over the first 64 KiB of a file plus its total size.
-// Used to detect replaced files so stale bookmarks are not silently applied.
-// Not a cryptographic hash.
-static uint64_t ComputeFileHash(const std::filesystem::path& path) noexcept {
-  try {
-    const auto size = std::filesystem::file_size(path);
-    std::ifstream file(path, std::ios::binary);
-    if (!file) {
-      return 0;
-    }
-    const auto readSize = static_cast<std::streamsize>(
-      std::min<std::uintmax_t>(size, 65536));
-    std::vector<char> buf(readSize);
-    file.read(buf.data(), readSize);
-    const auto n = static_cast<std::size_t>(file.gcount());
-    uint64_t hash = size;
-    for (std::size_t i = 0; i < n; ++i) {
-      hash = hash * 31 + static_cast<uint8_t>(buf[i]);
-    }
-    return hash ? hash : 1;
-  } catch (...) {
-    return 0;
-  }
-}
 
 task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
   const nlohmann::json tab) {
@@ -139,79 +115,21 @@ task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
   }
 
   if (tab.contains("Bookmarks")) {
-    if (const auto singleFile =
-          std::dynamic_pointer_cast<SingleFileTab>(result)) {
-      // SingleFileTab: {"FileHash": N, "Pages": [{"PageIndex": k, "Title": "..."}]}
-      const auto& bm = tab.at("Bookmarks");
-      if (bm.contains("FileHash") && bm.contains("Pages")) {
-        const auto storedHash = bm.at("FileHash").get<uint64_t>();
-        const auto& path = singleFile->GetPath();
-        if (!std::filesystem::exists(path)) {
-          dprint(
-            "Discarding bookmarks for '{}': file not found", path.string());
-        } else {
-          const auto currentHash = ComputeFileHash(path);
-          if (currentHash == 0 || currentHash != storedHash) {
-            dprint(
-              "Discarding bookmarks for '{}': file content has changed",
-              path.string());
-          } else {
-            TabBase::PendingBookmarkData pending;
-            pending.mFileHash = storedHash;
-            for (const auto& entry: bm.at("Pages")) {
-              if (!entry.contains("PageIndex") || !entry.contains("Title")) {
-                continue;
-              }
-              pending.mPages.emplace_back(
-                entry.at("PageIndex").get<PageIndex>(),
-                entry.at("Title").get<std::string>());
-            }
-            if (!pending.mPages.empty()) {
-              singleFile->SetPendingBookmarkRestore(std::move(pending));
-            }
-          }
-        }
-      }
-    } else if (
-      const auto folder = std::dynamic_pointer_cast<FolderTab>(result)) {
-      // FolderTab: [{"File": "...", "FileHash": N, "LocalPageIndex": k, "Title": "..."}]
-      if (!std::filesystem::is_directory(folder->GetPath())) {
-        dprint(
-          "Discarding bookmarks for folder '{}': directory not found",
-          folder->GetPath().string());
-      } else {
-        std::vector<FolderTab::FolderPendingBookmark> pending;
-        for (const auto& entry: tab.at("Bookmarks")) {
-          if (!entry.contains("File") || !entry.contains("FileHash")
-              || !entry.contains("LocalPageIndex")
-              || !entry.contains("Title")) {
-            continue;
-          }
-          const std::filesystem::path relFile {
-            entry.at("File").get<std::string>()};
-          const auto storedHash = entry.at("FileHash").get<uint64_t>();
-          const auto absFile = folder->GetPath() / relFile;
-          if (!std::filesystem::exists(absFile)) {
-            dprint(
-              "Skipping bookmark: file not found '{}'", absFile.string());
-            continue;
-          }
-          const auto currentHash = ComputeFileHash(absFile);
-          if (currentHash == 0 || currentHash != storedHash) {
-            dprint(
-              "Skipping bookmark: file content changed '{}'",
-              absFile.string());
+    if (const auto tabBase = std::dynamic_pointer_cast<TabBase>(result)) {
+      const auto& bmArray = tab.at("Bookmarks");
+      if (bmArray.is_array()) {
+        std::vector<TabBase::PendingBookmark> pending;
+        for (const auto& entry: bmArray) {
+          if (!entry.contains("PersistentID") || !entry.contains("Title")) {
             continue;
           }
           pending.push_back({
-            relFile,
-            storedHash,
-            entry.at("LocalPageIndex").get<PageIndex>(),
+            entry.at("PersistentID"),
             entry.at("Title").get<std::string>(),
           });
         }
         if (!pending.empty()) {
-          folder->SetFolderPendingBookmarkRestore(std::move(pending));
+          tabBase->SetPendingBookmarkRestore(std::move(pending));
         }
       }
     }
@@ -301,85 +219,24 @@ nlohmann::json TabsList::GetSettings() const {
       }
     }
 
-    if (const auto singleFile =
-          std::dynamic_pointer_cast<SingleFileTab>(tab)) {
-      // SingleFileTab: persist bookmarks guarded by a file content hash.
-      nlohmann::json bmJson;
-      const auto liveBookmarks = singleFile->GetBookmarks();
-      if (!liveBookmarks.empty()) {
-        const auto& path = singleFile->GetPath();
-        if (std::filesystem::exists(path)) {
-          const auto hash = ComputeFileHash(path);
-          if (hash != 0) {
-            nlohmann::json pages = nlohmann::json::array();
-            const auto pageIDs = singleFile->GetPageIDs();
-            for (const auto& bm: liveBookmarks) {
-              const auto it = std::ranges::find(pageIDs, bm.mPageID);
-              if (it == pageIDs.end()) {
-                continue;
-              }
-              pages.push_back({
-                {"PageIndex",
-                 static_cast<PageIndex>(
-                   std::distance(pageIDs.begin(), it))},
-                {"Title", bm.mTitle},
-              });
-            }
-            if (!pages.empty()) {
-              bmJson = {{"FileHash", hash}, {"Pages", std::move(pages)}};
-            }
-          }
-        }
-      } else if (const auto pending = singleFile->GetPendingBookmarkData()) {
-        // Pass-through during startup before content is loaded.
-        if (pending->mFileHash != 0 && !pending->mPages.empty()) {
-          nlohmann::json pages = nlohmann::json::array();
-          for (const auto& [idx, title]: pending->mPages) {
-            pages.push_back({{"PageIndex", idx}, {"Title", title}});
-          }
-          bmJson = {
-            {"FileHash", pending->mFileHash}, {"Pages", std::move(pages)}};
-        }
-      }
-      if (!bmJson.is_null()) {
-        savedTab.emplace("Bookmarks", std::move(bmJson));
-      }
-    } else if (
-      const auto folder = std::dynamic_pointer_cast<FolderTab>(tab)) {
-      // FolderTab: persist bookmarks keyed by relative file path and hash.
+    if (const auto tabBase = std::dynamic_pointer_cast<TabBase>(tab)) {
       nlohmann::json bmArray = nlohmann::json::array();
-      const auto liveBookmarks = folder->GetBookmarks();
+      const auto liveBookmarks = tabBase->GetBookmarks();
       if (!liveBookmarks.empty()) {
-        if (const auto* src = folder->GetPageSource()) {
-          for (const auto& bm: liveBookmarks) {
-            const auto info = src->GetFileAndLocalIndexForPageID(bm.mPageID);
-            if (!info) {
-              continue;
-            }
-            const auto absFile = folder->GetPath() / info->first;
-            if (!std::filesystem::exists(absFile)) {
-              continue;
-            }
-            const auto hash = ComputeFileHash(absFile);
-            if (hash == 0) {
-              continue;
-            }
+        for (const auto& bm: liveBookmarks) {
+          if (auto persistentID = tabBase->GetPersistentIDForPage(bm.mPageID)) {
             bmArray.push_back({
-              {"File", info->first.generic_string()},
-              {"FileHash", hash},
-              {"LocalPageIndex", info->second},
+              {"PersistentID", std::move(*persistentID)},
               {"Title", bm.mTitle},
             });
           }
         }
       } else {
         // Pass-through during startup before content is loaded.
-        for (const auto& p: folder->GetFolderPendingBookmarkData()) {
+        for (const auto& pending: tabBase->GetPendingBookmarkData()) {
           bmArray.push_back({
-            {"File", p.mRelFile.generic_string()},
-            {"FileHash", p.mFileHash},
-            {"LocalPageIndex", p.mLocalPageIndex},
-            {"Title", p.mTitle},
+            {"PersistentID", pending.mPersistentID},
+            {"Title", pending.mTitle},
           });
         }
       }

--- a/src/app/app-common/TabsList/TabsList.cpp
+++ b/src/app/app-common/TabsList/TabsList.cpp
@@ -9,6 +9,7 @@
 #include <OpenKneeboard/DCSRadioLogTab.hpp>
 #include <OpenKneeboard/DCSTerrainTab.hpp>
 #include <OpenKneeboard/Filesystem.hpp>
+#include <OpenKneeboard/FolderPageSource.hpp>
 #include <OpenKneeboard/KneeboardState.hpp>
 #include <OpenKneeboard/PluginTab.hpp>
 #include <OpenKneeboard/RuntimeFiles.hpp>
@@ -21,6 +22,9 @@
 #include <shims/nlohmann/json.hpp>
 
 #include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <vector>
 
 namespace OpenKneeboard {
 
@@ -51,6 +55,31 @@ static std::tuple<std::string, nlohmann::json> MigrateTab(
   return {type, settings};
 }
 
+// Polynomial hash over the first 64 KiB of a file plus its total size.
+// Used to detect replaced files so stale bookmarks are not silently applied.
+// Not a cryptographic hash.
+static uint64_t ComputeFileHash(const std::filesystem::path& path) noexcept {
+  try {
+    const auto size = std::filesystem::file_size(path);
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+      return 0;
+    }
+    const auto readSize = static_cast<std::streamsize>(
+      std::min<std::uintmax_t>(size, 65536));
+    std::vector<char> buf(readSize);
+    file.read(buf.data(), readSize);
+    const auto n = static_cast<std::size_t>(file.gcount());
+    uint64_t hash = size;
+    for (std::size_t i = 0; i < n; ++i) {
+      hash = hash * 31 + static_cast<uint8_t>(buf[i]);
+    }
+    return hash ? hash : 1;
+  } catch (...) {
+    return 0;
+  }
+}
+
 task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
   const nlohmann::json tab) {
   if (!(tab.contains("Type") && tab.contains("Title"))) {
@@ -73,21 +102,21 @@ task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
     // else handled by TabBase
   }
 
+  std::shared_ptr<ITab> result;
   try {
 #define IT(_, it) \
   if (type == #it) { \
     auto instance = co_await load_tab<it##Tab>( \
       mDXR, mKneeboard, persistentID, title, settings); \
     if (instance) { \
-      co_return instance; \
+      result = instance; \
     } \
   }
     OPENKNEEBOARD_TAB_TYPES
 #undef IT
-    if (type == "Plugin") {
-      auto instance = co_await PluginTab::Create(
+    if (!result && type == "Plugin") {
+      result = co_await PluginTab::Create(
         mDXR, mKneeboard, persistentID, title, settings);
-      co_return instance;
     }
   } catch (const std::exception& e) {
     dprint.Error(
@@ -102,9 +131,93 @@ task<std::shared_ptr<ITab>> TabsList::LoadTabFromJSON(
       winrt::to_string(e.message()));
     throw;
   }
-  dprint("Couldn't load tab with type {}", rawType);
-  OPENKNEEBOARD_BREAK;
-  co_return nullptr;
+
+  if (!result) {
+    dprint("Couldn't load tab with type {}", rawType);
+    OPENKNEEBOARD_BREAK;
+    co_return nullptr;
+  }
+
+  if (tab.contains("Bookmarks")) {
+    if (const auto singleFile =
+          std::dynamic_pointer_cast<SingleFileTab>(result)) {
+      // SingleFileTab: {"FileHash": N, "Pages": [{"PageIndex": k, "Title": "..."}]}
+      const auto& bm = tab.at("Bookmarks");
+      if (bm.contains("FileHash") && bm.contains("Pages")) {
+        const auto storedHash = bm.at("FileHash").get<uint64_t>();
+        const auto& path = singleFile->GetPath();
+        if (!std::filesystem::exists(path)) {
+          dprint(
+            "Discarding bookmarks for '{}': file not found", path.string());
+        } else {
+          const auto currentHash = ComputeFileHash(path);
+          if (currentHash == 0 || currentHash != storedHash) {
+            dprint(
+              "Discarding bookmarks for '{}': file content has changed",
+              path.string());
+          } else {
+            TabBase::PendingBookmarkData pending;
+            pending.mFileHash = storedHash;
+            for (const auto& entry: bm.at("Pages")) {
+              if (!entry.contains("PageIndex") || !entry.contains("Title")) {
+                continue;
+              }
+              pending.mPages.emplace_back(
+                entry.at("PageIndex").get<PageIndex>(),
+                entry.at("Title").get<std::string>());
+            }
+            if (!pending.mPages.empty()) {
+              singleFile->SetPendingBookmarkRestore(std::move(pending));
+            }
+          }
+        }
+      }
+    } else if (
+      const auto folder = std::dynamic_pointer_cast<FolderTab>(result)) {
+      // FolderTab: [{"File": "...", "FileHash": N, "LocalPageIndex": k, "Title": "..."}]
+      if (!std::filesystem::is_directory(folder->GetPath())) {
+        dprint(
+          "Discarding bookmarks for folder '{}': directory not found",
+          folder->GetPath().string());
+      } else {
+        std::vector<FolderTab::FolderPendingBookmark> pending;
+        for (const auto& entry: tab.at("Bookmarks")) {
+          if (!entry.contains("File") || !entry.contains("FileHash")
+              || !entry.contains("LocalPageIndex")
+              || !entry.contains("Title")) {
+            continue;
+          }
+          const std::filesystem::path relFile {
+            entry.at("File").get<std::string>()};
+          const auto storedHash = entry.at("FileHash").get<uint64_t>();
+          const auto absFile = folder->GetPath() / relFile;
+          if (!std::filesystem::exists(absFile)) {
+            dprint(
+              "Skipping bookmark: file not found '{}'", absFile.string());
+            continue;
+          }
+          const auto currentHash = ComputeFileHash(absFile);
+          if (currentHash == 0 || currentHash != storedHash) {
+            dprint(
+              "Skipping bookmark: file content changed '{}'",
+              absFile.string());
+            continue;
+          }
+          pending.push_back({
+            relFile,
+            storedHash,
+            entry.at("LocalPageIndex").get<PageIndex>(),
+            entry.at("Title").get<std::string>(),
+          });
+        }
+        if (!pending.empty()) {
+          folder->SetFolderPendingBookmarkRestore(std::move(pending));
+        }
+      }
+    }
+  }
+
+  co_return result;
 }
 
 task<void> TabsList::LoadSettings(nlohmann::json config) {
@@ -187,6 +300,94 @@ nlohmann::json TabsList::GetSettings() const {
         savedTab.emplace("Settings", settings);
       }
     }
+
+    if (const auto singleFile =
+          std::dynamic_pointer_cast<SingleFileTab>(tab)) {
+      // SingleFileTab: persist bookmarks guarded by a file content hash.
+      nlohmann::json bmJson;
+      const auto liveBookmarks = singleFile->GetBookmarks();
+      if (!liveBookmarks.empty()) {
+        const auto& path = singleFile->GetPath();
+        if (std::filesystem::exists(path)) {
+          const auto hash = ComputeFileHash(path);
+          if (hash != 0) {
+            nlohmann::json pages = nlohmann::json::array();
+            const auto pageIDs = singleFile->GetPageIDs();
+            for (const auto& bm: liveBookmarks) {
+              const auto it = std::ranges::find(pageIDs, bm.mPageID);
+              if (it == pageIDs.end()) {
+                continue;
+              }
+              pages.push_back({
+                {"PageIndex",
+                 static_cast<PageIndex>(
+                   std::distance(pageIDs.begin(), it))},
+                {"Title", bm.mTitle},
+              });
+            }
+            if (!pages.empty()) {
+              bmJson = {{"FileHash", hash}, {"Pages", std::move(pages)}};
+            }
+          }
+        }
+      } else if (const auto pending = singleFile->GetPendingBookmarkData()) {
+        // Pass-through during startup before content is loaded.
+        if (pending->mFileHash != 0 && !pending->mPages.empty()) {
+          nlohmann::json pages = nlohmann::json::array();
+          for (const auto& [idx, title]: pending->mPages) {
+            pages.push_back({{"PageIndex", idx}, {"Title", title}});
+          }
+          bmJson = {
+            {"FileHash", pending->mFileHash}, {"Pages", std::move(pages)}};
+        }
+      }
+      if (!bmJson.is_null()) {
+        savedTab.emplace("Bookmarks", std::move(bmJson));
+      }
+    } else if (
+      const auto folder = std::dynamic_pointer_cast<FolderTab>(tab)) {
+      // FolderTab: persist bookmarks keyed by relative file path and hash.
+      nlohmann::json bmArray = nlohmann::json::array();
+      const auto liveBookmarks = folder->GetBookmarks();
+      if (!liveBookmarks.empty()) {
+        if (const auto* src = folder->GetPageSource()) {
+          for (const auto& bm: liveBookmarks) {
+            const auto info = src->GetFileAndLocalIndexForPageID(bm.mPageID);
+            if (!info) {
+              continue;
+            }
+            const auto absFile = folder->GetPath() / info->first;
+            if (!std::filesystem::exists(absFile)) {
+              continue;
+            }
+            const auto hash = ComputeFileHash(absFile);
+            if (hash == 0) {
+              continue;
+            }
+            bmArray.push_back({
+              {"File", info->first.generic_string()},
+              {"FileHash", hash},
+              {"LocalPageIndex", info->second},
+              {"Title", bm.mTitle},
+            });
+          }
+        }
+      } else {
+        // Pass-through during startup before content is loaded.
+        for (const auto& p: folder->GetFolderPendingBookmarkData()) {
+          bmArray.push_back({
+            {"File", p.mRelFile.generic_string()},
+            {"FileHash", p.mFileHash},
+            {"LocalPageIndex", p.mLocalPageIndex},
+            {"Title", p.mTitle},
+          });
+        }
+      }
+      if (!bmArray.empty()) {
+        savedTab.emplace("Bookmarks", std::move(bmArray));
+      }
+    }
+
     ret.push_back(savedTab);
     continue;
   }


### PR DESCRIPTION
- Scope limited to SingleFileTab and FolderTab; PageIndex is unstable for tab types that regenerate content at runtime
- SingleFileTab bookmarks are guarded by a content hash: if the file is replaced or modified, stored bookmarks are discarded silently
- FolderTab bookmarks use relative filename + local page index as the persistent key, stable across file additions/deletions in the folder
- Per-file content hash validation for each FolderTab bookmark entry