### PR TITLE
Fix bookmark sidebar divider bleeding into content area

### DIFF
--- a/src/app/app-common/UILayers/BookmarksUILayer.cpp
+++ b/src/app/app-common/UILayers/BookmarksUILayer.cpp
@@ -225,11 +225,15 @@ task<void> BookmarksUILayer::Render(
   co_await first->Render(rc, rest, context, nextArea);
   d2d.Reacquire();
 
-  d2d->DrawLine(
-    {rect.Left() + (width * scale) - 1.0f, rect.Top<float>()},
-    {rect.Left() + (width * scale) - 1.0f, rect.Bottom<float>()},
-    mTextBrush.get(),
-    2.0f);
+  {
+    static constexpr auto Thickness = 2.0f;
+    const auto centerX = (rect.Left() + (width * scale)) - (Thickness / 2);
+    d2d->DrawLine(
+      {centerX, rect.Top<float>()},
+      {centerX, rect.Bottom<float>()},
+      mTextBrush.get(),
+      Thickness);
+  }
 }
 
 bool BookmarksUILayer::IsEnabled() const {

--- a/src/app/app-common/UILayers/BookmarksUILayer.cpp
+++ b/src/app/app-common/UILayers/BookmarksUILayer.cpp
@@ -211,8 +211,8 @@ task<void> BookmarksUILayer::Render(
     }
     if (buttonNumber != 1) {
       d2d->DrawLine(
-        {rect.Left<FLOAT>(), buttonRect.top},
-        {rect.Left<FLOAT>() + buttonRect.right, buttonRect.top},
+        {buttonRect.left, buttonRect.top},
+        {buttonRect.right, buttonRect.top},
         mTextBrush.get(),
         2.0f);
     }
@@ -226,8 +226,8 @@ task<void> BookmarksUILayer::Render(
   d2d.Reacquire();
 
   d2d->DrawLine(
-    {rect.Left() + (width * scale), rect.Top<float>()},
-    {rect.Left() + (width * scale), rect.Bottom<float>()},
+    {rect.Left() + (width * scale) - 1.0f, rect.Top<float>()},
+    {rect.Left() + (width * scale) - 1.0f, rect.Bottom<float>()},
     mTextBrush.get(),
     2.0f);
 }


### PR DESCRIPTION
The vertical divider DrawLine was centered exactly at the sidebar/content boundary, with stroke width 2.0, one pixel bled into the content area.                       Shift the center 1px inward so the stroke stays within the sidebar.