### PR TITLE
🐛💄 pixel-align the in-game chrome

### DIFF
--- a/src/app/app-common/UILayers/BookmarksUILayer.cpp
+++ b/src/app/app-common/UILayers/BookmarksUILayer.cpp
@@ -140,16 +140,25 @@ task<void> BookmarksUILayer::Render(
   const auto scale =
     rect.Width<float>() / metrics.mPreferredSize.mPixelSize.mWidth;
 
-  auto d2d = rc.d2d();
-  d2d->FillRectangle(
-    PixelRect {
-      rect.mOffset,
-      {
-        static_cast<uint32_t>(std::lround(metrics.mNextArea.Left() * scale)),
-        rect.Height(),
-      },
+  const auto nextWidth =
+    static_cast<unsigned int>(std::lround(metrics.mNextArea.Width() * scale));
+  const PixelRect nextArea {
+    PixelPoint {
+      rect.Right() - nextWidth,
+      rect.Top(),
     },
-    mBackgroundBrush.get());
+    PixelSize {nextWidth, rect.Height()},
+  };
+  const PixelRect bookmarksArea {
+    rect.TopLeft(),
+    PixelSize {
+      (nextArea.Left() - rect.Left()),
+      rect.Height(),
+    },
+  };
+
+  auto d2d = rc.d2d();
+  d2d->FillRectangle(bookmarksArea, mBackgroundBrush.get());
 
   auto [hoverButton, buttons] = this->LayoutButtons()->GetState();
 
@@ -185,10 +194,10 @@ task<void> BookmarksUILayer::Render(
   const auto currentPageID = currentTabView->GetPageID();
   for (const auto& button: buttons) {
     const D2D1_RECT_F buttonRect {
-      rect.Left<float>(),
-      rect.Top() + (button.mRect.top * height * scale),
-      rect.Left() + (width * scale),
-      rect.Top() + (button.mRect.bottom * height * scale),
+      bookmarksArea.Left<FLOAT>(),
+      std::floor(rect.Top() + (button.mRect.top * height * scale)),
+      bookmarksArea.Right<FLOAT>(),
+      std::floor(rect.Top() + (button.mRect.bottom * height * scale)),
     };
     buttonNumber++;
     const auto text = winrt::to_hstring(
@@ -219,15 +228,12 @@ task<void> BookmarksUILayer::Render(
   }
 
   d2d.Release();
-  auto nextArea =
-    (metrics.mNextArea.StaticCast<float>() * scale).Rounded<uint32_t>();
-  nextArea.mOffset += rect.mOffset;
   co_await first->Render(rc, rest, context, nextArea);
   d2d.Reacquire();
 
   {
     static constexpr auto Thickness = 2.0f;
-    const auto centerX = (rect.Left() + (width * scale)) - (Thickness / 2);
+    const auto centerX = bookmarksArea.Right() - (Thickness / 2);
     d2d->DrawLine(
       {centerX, rect.Top<float>()},
       {centerX, rect.Bottom<float>()},

--- a/src/app/app-common/UILayers/FooterUILayer.cpp
+++ b/src/app/app-common/UILayers/FooterUILayer.cpp
@@ -114,9 +114,9 @@ task<void> FooterUILayer::Render(
 
   const auto scale = rect.Height<float>() / preferredSize.mHeight;
 
-  const auto contentHeight = scale * metrics.mContentArea.Height();
-  const auto footerHeight = static_cast<uint32_t>(
-    std::lround(contentHeight * (FooterPercent / 100.0f)));
+  const auto contentHeight =
+    static_cast<uint32_t>(std::lround(scale * metrics.mContentArea.Height()));
+  const auto footerHeight = rect.Height() - contentHeight;
 
   const PixelRect footerRect {
     {rect.Left(), rect.Bottom() - footerHeight},
@@ -127,9 +127,9 @@ task<void> FooterUILayer::Render(
     rc,
     next.subspan(1),
     context,
-    {
-      rect.mOffset,
-      (metrics.mNextArea.mSize.StaticCast<float>() * scale).Rounded<uint32_t>(),
+    PixelRect {
+      rect.TopLeft(),
+      {rect.Width(), contentHeight},
     });
 
   auto d2d = rc.d2d();

--- a/src/app/app-common/UILayers/HeaderUILayer.cpp
+++ b/src/app/app-common/UILayers/HeaderUILayer.cpp
@@ -153,10 +153,9 @@ task<void> HeaderUILayer::Render(
 
   const auto scale = rect.Height<float>() / preferredSize.mPixelSize.mHeight;
 
-  const auto contentHeight =
-    static_cast<uint32_t>(std::lround(scale * metrics.mContentArea.Height()));
-  const auto headerHeight = static_cast<uint32_t>(
-    std::lround(contentHeight * (HeaderPercent / 100.0f)));
+  const auto nextHeight =
+    static_cast<uint32_t>(std::lround(scale * metrics.mNextArea.Height()));
+  const auto headerHeight = rect.Height() - nextHeight;
 
   const PixelRect headerRect {
     rect.mOffset,
@@ -184,7 +183,7 @@ task<void> HeaderUILayer::Render(
     context,
     {
       {rect.Left(), rect.Top() + headerHeight},
-      {rect.Width(), rect.Height() - headerHeight},
+      {rect.Width(), nextHeight},
     });
 
   auto secondaryMenu = mSecondaryMenu;


### PR DESCRIPTION
This doesn't typically 'matter' for rendering in VR (as it's never going to be pixel-aligned in headset), but it does matter for cropping, e.g. when the header/footer are turned off in the view settings.

Two kinds of changes:
- use floor/ceil/round to get integer values
- only use float math for either the UI layer's rect or the next rect; use integer math for the other so they line up exactly

This likely didn't show up in #904 because it's mostly going to affect page sources that support vector scaling, e.g. text and PDFs. window captures and pngs are fundamentally pixel data, so are unscaled as long as they fit within the limits.

I saw issues in the DCS tabs because they are backed by plain text page sources, which in turn support vector scaling.