### PR TITLE
🐛 fix crash rendering bookmarks bar if width is 0

### DIFF
--- a/src/app/app-common/UILayers/BookmarksUILayer.cpp
+++ b/src/app/app-common/UILayers/BookmarksUILayer.cpp
@@ -107,6 +107,15 @@ IUILayer::Metrics BookmarksUILayer::GetMetrics(
   const auto width = static_cast<uint32_t>(std::lround(
     nextMetrics.mContentArea.mSize.mHeight * (BookmarksBarPercent / 100.0f)));
 
+  if (width == 0) {
+    auto ret = nextMetrics;
+    ret.mNextArea = {
+      {},
+      nextMetrics.mPreferredSize.mPixelSize,
+    };
+    return ret;
+  }
+
   return Metrics {
     nextMetrics.mPreferredSize.Extended({static_cast<uint32_t>(width), 0}),
     {
@@ -164,6 +173,11 @@ task<void> BookmarksUILayer::Render(
 
   const auto height = metrics.mPreferredSize.mPixelSize.mHeight;
   const auto width = metrics.mNextArea.Left();
+
+  if (width == 0) {
+    co_await first->Render(rc, rest, context, rect);
+    co_return;
+  }
 
   FLOAT dpix {}, dpiy {};
   d2d->GetDpi(&dpix, &dpiy);


### PR DESCRIPTION
This will avoid this crash :

```
OpenKneeboardApp.exe (PID 26176) crashed at 20260426T194816

💀 FATAL: Uncaught winrt::hresult_error: 0x0000000080070057 - Paramètre incorrect.

Metadata
========

Executable:  C:\Users\yvonn\src\OpenKneeboard\build\out\Debug\bin\OpenKneeboardApp.exe
Module:      C:\Users\yvonn\src\OpenKneeboard\build\out\Debug\bin\OpenKneeboardApp.exe
Thread:      23372 ("UI Thread")
Blame frame: C:\Users\yvonn\src\OpenKneeboard\src\lib\fatal.cpp:626 - OpenKneeboardApp!OpenKneeboard::fatal_with_exception+0x48
OKB Version: v1.13.0+local

Stack Trace
===========

0> C:\Users\yvonn\src\OpenKneeboard\src\lib\fatal.cpp(134): OpenKneeboardApp!OpenKneeboard::detail::CrashMeta::CrashMeta+0x2E
1> C:\Users\yvonn\src\OpenKneeboard\src\lib\fatal.cpp(626): OpenKneeboardApp!OpenKneeboard::fatal_with_exception+0x48
2> C:\Users\yvonn\src\OpenKneeboard\src\lib\include\OpenKneeboard\task.hpp(266): OpenKneeboardApp!OpenKneeboard::detail::TaskState<OpenKneeboard::detail::FireAndForgetTraits>::store_current_exception+0x10F
3> C:\Users\yvonn\src\OpenKneeboard\src\lib\include\OpenKneeboard\task.hpp(558): OpenKneeboardApp!OpenKneeboard::detail::TaskPromiseBase<OpenKneeboard::detail::FireAndForgetTraits>::unhandled_exception+0x37
4> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\MainWindow.xaml.cpp(264): OpenKneeboardApp!`winrt::OpenKneeboardApp::implementation::MainWindow::FrameLoop$_ResumeCoro$1'::`1'::catch$7+0x58
5> D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\amd64\handlers.asm(98): OpenKneeboardApp!_CallSettingFrame_LookupContinuationIndex+0x20
6> D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\frame.cpp(1439): OpenKneeboardApp!__FrameHandler4::CxxCallCatchBlock+0x1DE
7> ntdll!RtlCaptureContext2+0x4A6
8> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\MainWindow.xaml.cpp(237): OpenKneeboardApp!winrt::OpenKneeboardApp::implementation::MainWindow::FrameLoop$_ResumeCoro$1+0x9C5
9> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\MainWindow.xaml.cpp(15732480): OpenKneeboardApp!winrt::OpenKneeboardApp::implementation::MainWindow::FrameLoop+0x22A
10> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\MainWindow.xaml.cpp(415): OpenKneeboardApp!winrt::OpenKneeboardApp::implementation::MainWindow::OnLoaded$_ResumeCoro$1+0x83A
11> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\MainWindow.xaml.cpp(15732480): OpenKneeboardApp!winrt::OpenKneeboardApp::implementation::MainWindow::OnLoaded+0x22A
12> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\MainWindow.xaml.cpp(135): OpenKneeboardApp!`winrt::OpenKneeboardApp::implementation::MainWindow::Init'::`2'::<lambda_2>::operator()<winrt::Windows::Foundation::IInspectable,winrt::Microsoft::UI::Xaml::RoutedEventArgs>+0x30
13> C:\Users\yvonn\src\OpenKneeboard\build\src\app\app-winui3\Generated Files\winrt\Microsoft.UI.Xaml.h(4899): OpenKneeboardApp!winrt::impl::delegate<winrt::Microsoft::UI::Xaml::RoutedEventHandler,`winrt::OpenKneeboardApp::implementation::MainWindow::Init'::`2'::<lambda_2> >::Invoke+0x36
14> Microsoft_UI_Xaml+0xB067F
15> Microsoft_UI_Xaml+0xB0992
16> Microsoft_UI_Xaml+0x127044
17> Microsoft_UI_Xaml+0x126C6D
18> Microsoft_UI_Xaml+0x1C7DF1
19> Microsoft_UI_Xaml+0x16E837
20> Microsoft_UI_Xaml+0x16E261
21> Microsoft_UI_Xaml+0x737D8
22> Microsoft_UI_Xaml+0x734A9
23> Microsoft_UI_Xaml+0x1A1646
24> Microsoft_UI_Xaml+0x1A1317
25> Microsoft_UI_Xaml+0x31E9C
26> Microsoft_UI_Xaml+0x2A30D
27> Microsoft_UI_Xaml+0x2A187
28> Microsoft_UI_Xaml+0x2A0C9
29> Microsoft_UI_Xaml+0x16EE8A
30> Microsoft_UI_Xaml+0x16ED23
31> Microsoft_UI_Xaml+0x16E158
32> Microsoft_UI_Xaml+0x16E039
33> CoreMessagingXP!WinUIGetDispatcherQueueForCurrentThread+0x727
34> CoreMessagingXP!WinUICreateDispatcherQueueController+0x62F
35> CoreMessagingXP!WinUIGetDispatcherQueueForCurrentThread+0xBC3
36> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x3333D
37> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x37396
38> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x236D9
39> CoreMessagingXP!CoreUIRouteToTestRegistrar+0xF1C0
40> CoreMessagingXP!CoreUIRouteToTestRegistrar+0xEF2D
41> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x26BC
42> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x55A6
43> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x591C
44> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x45FE3
45> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x46176
46> CoreMessagingXP!CoreUIRouteToTestRegistrar+0x466EE
47> USER32!CallWindowProcW+0x6A6
48> USER32!SendMessageW+0xACC
49> USER32!GetWindowDpiAwarenessContext+0x4D3
50> ntdll!KiUserCallbackDispatcher+0x24
51> win32u!NtUserGetMessage+0x14
52> USER32!GetMessageW+0x22
53> Microsoft_UI_Xaml!DllGetActivationFactory+0x625EC
54> Microsoft_UI_Xaml!DllGetActivationFactory+0x62859
55> Microsoft_UI_Xaml+0x162250
56> C:\Users\yvonn\src\OpenKneeboard\build\src\app\app-winui3\Generated Files\winrt\Microsoft.UI.Xaml.h(184): OpenKneeboardApp!winrt::impl::consume_Microsoft_UI_Xaml_IApplicationStatics<winrt::Microsoft::UI::Xaml::IApplicationStatics>::Start+0x73
57> C:\Users\yvonn\src\OpenKneeboard\build\src\app\app-winui3\Generated Files\winrt\Microsoft.UI.Xaml.h(12441): OpenKneeboardApp!`winrt::Microsoft::UI::Xaml::Application::Start'::`2'::<lambda_1>::operator()+0x21
58> C:\Users\yvonn\src\OpenKneeboard\build\src\app\app-winui3\Generated Files\winrt\base.h(6565): OpenKneeboardApp!winrt::impl::factory_cache_entry<winrt::Microsoft::UI::Xaml::Application,winrt::Microsoft::UI::Xaml::IApplicationStatics>::call<`winrt::Microsoft::UI::Xaml::Application::Start'::`2'::<lambda_1> &>+0x187
59> C:\Users\yvonn\src\OpenKneeboard\build\src\app\app-winui3\Generated Files\winrt\base.h(6587): OpenKneeboardApp!winrt::impl::call_factory<winrt::Microsoft::UI::Xaml::Application,winrt::Microsoft::UI::Xaml::IApplicationStatics,`winrt::Microsoft::UI::Xaml::Application::Start'::`2'::<lambda_1> >+0x97
60> C:\Users\yvonn\src\OpenKneeboard\build\src\app\app-winui3\Generated Files\winrt\Microsoft.UI.Xaml.h(12441): OpenKneeboardApp!winrt::Microsoft::UI::Xaml::Application::Start+0x21
61> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\App.xaml.cpp(815): OpenKneeboardApp!AppMain+0xBFB
62> C:\Users\yvonn\src\OpenKneeboard\src\app\app-winui3\App.xaml.cpp(854): OpenKneeboardApp!wWinMain+0x1F7
63> D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(123): OpenKneeboardApp!invoke_main+0x32
64> D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(288): OpenKneeboardApp!__scrt_common_main_seh+0x132
65> D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(331): OpenKneeboardApp!__scrt_common_main+0xE
66> D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp(17): OpenKneeboardApp!wWinMainCRTStartup+0xE
67> KERNEL32!BaseThreadInitThunk+0x17
68> ntdll!RtlUserThreadStart+0x2C

